### PR TITLE
Use `ZonedDate` for ASN.1 GeneralizedTime and fix parsing

### DIFF
--- a/Sources/PotentASN1/ASN1.swift
+++ b/Sources/PotentASN1/ASN1.swift
@@ -96,7 +96,7 @@ public indirect enum ASN1: Value {
   case videotexString(String)
   case ia5String(String)
   case utcTime(Date)
-  case generalizedTime(Date)
+  case generalizedTime(ZonedDate)
   case graphicString(String)
   case visibleString(String)
   case generalString(String)
@@ -170,7 +170,7 @@ public indirect enum ASN1: Value {
     case .teletexString(let value): return AnyString(value, kind: .teletex)
     case .videotexString(let value): return AnyString(value, kind: .videotex)
     case .ia5String(let value): return AnyString(value, kind: .ia5)
-    case .utcTime(let value): return AnyTime(value, kind: .utc)
+    case .utcTime(let value): return AnyTime(date: value, timeZone: .utc, kind: .utc)
     case .generalizedTime(let value): return AnyTime(value, kind: .generalized)
     case .graphicString(let value): return AnyString(value, kind: .graphic)
     case .visibleString(let value): return AnyString(value, kind: .visible)
@@ -317,7 +317,7 @@ public extension ASN1 {
     return value
   }
 
-  var generalizedTimeValue: Date? {
+  var generalizedTimeValue: ZonedDate? {
     guard case .generalizedTime(let value) = absolute else { return nil }
     return value
   }
@@ -370,10 +370,10 @@ public extension ASN1 {
     }
   }
 
-  var timeValue: (Date, AnyTime.Kind)? {
+  var timeValue: (ZonedDate, AnyTime.Kind)? {
     switch absolute {
-    case .utcTime(let value): return (value, .utc)
-    case .generalizedTime(let value): return (value, .generalized)
+    case .utcTime(let date): return (ZonedDate(date: date, timeZone: .utc), .utc)
+    case .generalizedTime(let date): return (date, .generalized)
     default: return nil
     }
   }
@@ -449,7 +449,7 @@ extension ASN1: Codable {
     case .utcTime:
       self = .utcTime(try container.decode(Date.self))
     case .generalizedTime:
-      self = .generalizedTime(try container.decode(Date.self))
+      self = .generalizedTime(try container.decode(ZonedDate.self))
     case .graphicString:
       self = .graphicString(try container.decode(String.self))
     case .visibleString:

--- a/Sources/PotentASN1/ASN1Decoder.swift
+++ b/Sources/PotentASN1/ASN1Decoder.swift
@@ -590,12 +590,12 @@ extension SchemaState {
 
       case .time(kind: let requiredKind):
 
-        guard let (time, kind) = value.timeValue, requiredKind == kind else {
+        guard let (date, kind) = value.timeValue, requiredKind == kind else {
           // try next possible schema
           continue
         }
 
-        return AnyTime(time, kind: kind)
+        return AnyTime(date, kind: kind)
 
 
       case .string(kind: let requiredKind, size: let requiredSize):

--- a/Sources/PotentASN1/AnyTime.swift
+++ b/Sources/PotentASN1/AnyTime.swift
@@ -14,7 +14,7 @@ import PotentCodables
 
 /// Allows encoding _any_ ASN.1 time value while controlling the specific ASN.1 type.
 ///
-public struct AnyTime: Equatable, Hashable {
+public struct AnyTime: Equatable, Hashable, Codable {
 
 
   public enum Kind: Int, Equatable, Hashable, Codable {
@@ -24,26 +24,16 @@ public struct AnyTime: Equatable, Hashable {
 
 
   public var kind: Kind?
-  public var storage: Date
+  public var zonedDate: ZonedDate
 
-  public init(_ value: Date = Date(), kind: Kind? = nil) {
+  public init(_ zonedDate: ZonedDate, kind: Kind? = nil) {
     self.kind = kind
-    storage = value
+    self.zonedDate = zonedDate
   }
 
-}
-
-
-extension AnyTime: Codable {
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    storage = try container.decode(Date.self)
-  }
-
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(storage)
+  public init(date: Date, timeZone: TimeZone, kind: Kind? = nil) {
+    self.kind = kind
+    self.zonedDate = ZonedDate(date: date, timeZone: timeZone)
   }
 
 }

--- a/Sources/PotentASN1/BigInts.swift
+++ b/Sources/PotentASN1/BigInts.swift
@@ -23,6 +23,12 @@ public extension BigUInt {
     return words[0]
   }
 
+  init(serialized data: Data) {
+    self.init(data)
+  }
+
+  func serialized() -> Data { serialize() }
+
 }
 
 public extension BigInt {
@@ -42,7 +48,7 @@ public extension BigInt {
 
   /// Initializes an integer from the bits stored inside a piece of `Data`.
   /// The data is assumed to be the two's compliment base-256 representation, in network (big-endian) byte order.
-  init(_ data: Data) {
+  init(serialized data: Data) {
     let sign: Sign
     let magnitude: BigUInt
     if (data[0] & 0x80) == 0x80 {
@@ -57,7 +63,7 @@ public extension BigInt {
   }
 
   /// Return a `Data` value that contains the two's compliment base-256 representation of this integer, in network (big-endian) byte order.
-  func serialize() -> Data {
+  func serialized() -> Data {
     var bytes = magnitude.serialize()
     if bytes.isEmpty || (bytes[0] & 0x80) == 0x80 {
       // Make room for sign

--- a/Sources/PotentCodables/TimeZone.swift
+++ b/Sources/PotentCodables/TimeZone.swift
@@ -1,0 +1,65 @@
+//
+//  TimeZone.swift
+//  PotentCodables
+//
+//  Created by Kevin Wooten on 9/12/21.
+//
+
+import Foundation
+
+extension TimeZone {
+
+  public static let utc = TimeZone(identifier: "UTC")!
+
+  public static func timeZone(from date: String) -> TimeZone? {
+    guard let offset = offset(from: date) else {
+      return nil
+    }
+    return TimeZone(secondsFromGMT: offset)
+  }
+
+  public static func offset(from date: String) -> Int? {
+    guard let start = date.firstIndex(of: "+") ?? date.firstIndex(of: "-") ?? date.firstIndex(of: "Z") else {
+      return nil
+    }
+    guard date[start] != "Z" else {
+      return 0
+    }
+
+    let sign = date[start] == "+" ? 1 : -1
+    func build(seconds: Int) -> Int? {
+      return seconds * sign
+    }
+
+    let tz = date[date.index(after: start) ..< date.endIndex]
+
+    if tz.count == 2 { // assume HH
+      if let hour = Int(tz) {
+        return build(seconds: hour * 3600)
+      }
+    }
+    else if tz.count == 4 { // assume HHMM
+      if let hour = Int(tz.dropLast(2)), let min = Int(tz.dropFirst(2)) {
+        return build(seconds: (hour * 60 + min) * 60)
+      }
+    }
+    else if tz.count == 5 { // assime HH:MM
+      if let hour = Int(tz.dropLast(3)), let min = Int(tz.dropFirst(3)) {
+        return build(seconds: (hour * 60 + min) * 60)
+      }
+    }
+    else if tz.count == 6 { // assume HHMMSS
+      if let hour = Int(tz.dropLast(4)), let min = Int(tz.dropFirst(2).dropLast(2)), let sec = Int(tz.dropFirst(4)) {
+        return build(seconds: (hour * 60 + min) * 60 + sec)
+      }
+    }
+    else if tz.count == 8 { // assime HH:MM:SS
+      if let hour = Int(tz.dropLast(6)), let min = Int(tz.dropFirst(3).dropLast(3)), let sec = Int(tz.dropFirst(6)) {
+        return build(seconds: (hour * 60 + min) * 60 + sec)
+      }
+    }
+
+    return nil
+  }
+
+}

--- a/Sources/PotentCodables/ZonedDate.swift
+++ b/Sources/PotentCodables/ZonedDate.swift
@@ -1,0 +1,65 @@
+//
+//  ZonedDate.swift
+//  PotentCodables
+//
+//  Copyright © 2019 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Foundation
+
+public struct ZonedDate: Equatable, Hashable, Codable {
+
+  public var date: Date
+  public var timeZone: TimeZone
+
+  public var utcDate: Date {
+    if timeZone == .utc {
+      return date
+    }
+    let offset = timeZone.daylightSavingTimeOffset(for: date)
+    return Date(timeInterval: -offset, since: date)
+  }
+
+  public init(date: Date, timeZone: TimeZone) {
+    self.date = date
+    self.timeZone = timeZone
+  }
+
+}
+
+extension ZonedDate: CustomStringConvertible {
+
+  public var description: String {
+    return Formatters.for(timeZone: timeZone).string(from: date)
+  }
+
+}
+
+private enum Formatters {
+
+  private static var formatters: [TimeZone: DateFormatter] = [:]
+  private static let formattersLock = NSLock()
+
+  static func `for`(timeZone: TimeZone) -> DateFormatter {
+    formattersLock.lock()
+    defer { formattersLock.unlock() }
+
+    if let found = formatters[timeZone] {
+      return found
+    }
+
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .iso8601)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = timeZone
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS XXXXX"
+
+    formatters[timeZone] = formatter
+
+    return formatter
+  }
+
+}

--- a/Tests/ASN1Tests.swift
+++ b/Tests/ASN1Tests.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import PotentASN1
+import PotentCodables
 import XCTest
 
 
@@ -56,6 +57,130 @@ class ASN1Tests: XCTestCase {
     let dst = try ASN1Decoder(schema: TestStructSchema).decode(TestStruct.self, from: srcData)
     
     XCTAssertEqual(src, dst)
+  }
+
+  func testGeneralizedTimeEncodingDecoding() throws {
+
+    struct TestStruct: Codable, Equatable {
+      let a: AnyTime
+      let b: AnyTime
+    }
+
+    let TestStructSchema: Schema =
+      .sequence([
+        "a": .time(kind: .generalized),
+        "b": .time(kind: .generalized),
+      ])
+
+    let src = TestStruct(
+      a: AnyTime(date: Date().truncatedToSecs, timeZone: .utc, kind: .generalized),
+      b: AnyTime(date: Date().truncatedToSecs, timeZone: .timeZone(from: "+1122")!, kind: .generalized)
+    )
+    let srcData = try ASN1Encoder(schema: TestStructSchema).encode(src)
+    let dst = try ASN1Decoder(schema: TestStructSchema).decode(TestStruct.self, from: srcData)
+
+    XCTAssertEqual(src, dst)
+  }
+
+  func testGeneralizedTimeReadingWriting() throws {
+
+    let writer = DERWriter()
+    try writer.write(ASN1.tagged(24, "22221111223344".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567".data(using: .ascii)!))
+
+    try writer.write(ASN1.tagged(24, "22221111223344Z".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567Z".data(using: .ascii)!))
+
+    try writer.write(ASN1.tagged(24, "22221111223344+11:22:33".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567+11:22:33".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344+112233".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567+112233".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344+11:22".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567+11:22".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344+1122".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567+1122".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344+11".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567+11".data(using: .ascii)!))
+
+    try writer.write(ASN1.tagged(24, "22221111223344-11:22:33".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567-11:22:33".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344-112233".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567-112233".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344-11:22".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567-11:22".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344-1122".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567-1122".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344-11".data(using: .ascii)!))
+    try writer.write(ASN1.tagged(24, "22221111223344.567-11".data(using: .ascii)!))
+
+    let values = try DERReader.parse(data: writer.data)
+
+    func date(_ index: Int) -> TimeInterval { values[index].generalizedTimeValue!.date.timeIntervalSince1970 }
+    func tz(_ index: Int) -> TimeZone { values[index].generalizedTimeValue!.timeZone }
+    func offset(_ index: Int) -> Int { values[index].generalizedTimeValue!.timeZone.secondsFromGMT() }
+
+    XCTAssertEqual(date(0), 7979553224.0)
+    XCTAssertEqual(tz(0), .current)
+    XCTAssertEqual(date(1), 7979553224.567)
+    XCTAssertEqual(tz(1), .current)
+
+    XCTAssertEqual(date(2), 7979553224)
+    XCTAssertEqual(tz(2), .utc)
+    XCTAssertEqual(date(3), 7979553224.567)
+    XCTAssertEqual(tz(3), .utc)
+
+    XCTAssertEqual(date(4), 7979553224-40953)
+    XCTAssertEqual(offset(4), 40980)
+    XCTAssertEqual(date(5), 7979553224.567-40953)
+    XCTAssertEqual(offset(5), 40980)
+    XCTAssertEqual(date(6), 7979553224-40953)
+    XCTAssertEqual(offset(6), 40980)
+    XCTAssertEqual(date(7), 7979553224.567-40953)
+    XCTAssertEqual(offset(7), 40980)
+    XCTAssertEqual(date(8), 7979553224-40920)
+    XCTAssertEqual(offset(8), 40920)
+    XCTAssertEqual(date(9), 7979553224.567-40920)
+    XCTAssertEqual(offset(9), 40920)
+    XCTAssertEqual(date(10), 7979553224-40920)
+    XCTAssertEqual(offset(10), 40920)
+    XCTAssertEqual(date(11), 7979553224.567-40920)
+    XCTAssertEqual(offset(11), 40920)
+    XCTAssertEqual(date(12), 7979553224-39600)
+    XCTAssertEqual(offset(12), 39600)
+    XCTAssertEqual(date(13), 7979553224.567-39600)
+    XCTAssertEqual(offset(13), 39600)
+
+    XCTAssertEqual(date(14), 7979553224+40953)
+    XCTAssertEqual(offset(14), -40980)
+    XCTAssertEqual(date(15), 7979553224.567+40953)
+    XCTAssertEqual(offset(15), -40980)
+    XCTAssertEqual(date(16), 7979553224+40953)
+    XCTAssertEqual(offset(16), -40980)
+    XCTAssertEqual(date(17), 7979553224.567+40953)
+    XCTAssertEqual(offset(17), -40980)
+    XCTAssertEqual(date(18), 7979553224+40920)
+    XCTAssertEqual(offset(18), -40920)
+    XCTAssertEqual(date(19), 7979553224.567+40920)
+    XCTAssertEqual(offset(19), -40920)
+    XCTAssertEqual(date(20), 7979553224+40920)
+    XCTAssertEqual(offset(20), -40920)
+    XCTAssertEqual(date(21), 7979553224.567+40920)
+    XCTAssertEqual(offset(21), -40920)
+    XCTAssertEqual(date(22), 7979553224+39600)
+    XCTAssertEqual(offset(22), -39600)
+    XCTAssertEqual(date(23), 7979553224.567+39600)
+    XCTAssertEqual(offset(23), -39600)
+  }
+
+}
+
+
+extension Date {
+
+  var truncatedToSecs: Date { Date(timeIntervalSinceReferenceDate: timeIntervalSinceReferenceDate.rounded()) }
+
+  var millisecondsFromReferenceDate: TimeInterval {
+    return (timeIntervalSinceReferenceDate * 1000.0).rounded() / 1000.0
   }
 
 }

--- a/Tests/BigIntTests.swift
+++ b/Tests/BigIntTests.swift
@@ -17,35 +17,35 @@ class BigIntTests: XCTestCase {
 
   func testSerialize() {
     let src1 = BigInt(sign: .minus, magnitude: BigUInt(0xFFFFFFFF))
-    let dst1 = BigInt(src1.serialize())
+    let dst1 = BigInt(serialized: src1.serialized())
     XCTAssertEqual(src1, dst1)
 
     let src2 = BigInt(sign: .plus, magnitude: BigUInt(0xFFFFFFFF))
-    let dst2 = BigInt(src2.serialize())
+    let dst2 = BigInt(serialized: src2.serialized())
     XCTAssertEqual(src2, dst2)
 
     let src3 = BigInt(sign: .minus, magnitude: BigUInt(0x10000000))
-    let dst3 = BigInt(src3.serialize())
+    let dst3 = BigInt(serialized: src3.serialized())
     XCTAssertEqual(src3, dst3)
 
     let src4 = BigInt(sign: .plus, magnitude: BigUInt(0x10000000))
-    let dst4 = BigInt(src4.serialize())
+    let dst4 = BigInt(serialized: src4.serialized())
     XCTAssertEqual(src4, dst4)
 
     let src5 = BigInt(sign: .minus, magnitude: BigUInt(0x0))
-    let dst5 = BigInt(src5.serialize())
+    let dst5 = BigInt(serialized: src5.serialized())
     XCTAssertEqual(src5, dst5)
 
     let src6 = BigInt(sign: .plus, magnitude: BigUInt(0x0))
-    let dst6 = BigInt(src6.serialize())
+    let dst6 = BigInt(serialized: src6.serialized())
     XCTAssertEqual(src6, dst6)
 
     let src7 = BigInt(sign: .minus, magnitude: BigUInt(0x1))
-    let dst7 = BigInt(src7.serialize())
+    let dst7 = BigInt(serialized: src7.serialized())
     XCTAssertEqual(src7, dst7)
 
     let src8 = BigInt(sign: .plus, magnitude: BigUInt(0x1))
-    let dst8 = BigInt(src8.serialize())
+    let dst8 = BigInt(serialized: src8.serialized())
     XCTAssertEqual(src8, dst8)
   }
 

--- a/Tests/TimeZoneTests.swift
+++ b/Tests/TimeZoneTests.swift
@@ -1,0 +1,83 @@
+//
+//  File.swift
+//  File
+//
+//  Created by Kevin Wooten on 9/12/21.
+//
+
+import Foundation
+import XCTest
+
+class TimeZoneTests: XCTestCase {
+
+  func testParsingOffsets() throws {
+
+    let noOff = TimeZone.offset(from: "20201212111111.000")
+    XCTAssertNil(noOff)
+
+    let utcOff = TimeZone.offset(from: "20201212111111.000Z")
+    XCTAssertEqual(utcOff, 0)
+
+    let aheadSecsOff1 = TimeZone.offset(from: "20201212111111.000+123456")
+    XCTAssertEqual(aheadSecsOff1, 45296)
+    let aheadSecsOff2 = TimeZone.offset(from: "20201212111111.000+12:34:56")
+    XCTAssertEqual(aheadSecsOff2, 45296)
+
+    let behindSecsOff1 = TimeZone.offset(from: "20201212111111.000-123456")
+    XCTAssertEqual(behindSecsOff1, -45296)
+    let behindSecsOff2 = TimeZone.offset(from: "20201212111111.000-12:34:56")
+    XCTAssertEqual(behindSecsOff2, -45296)
+
+    let aheadMinsOff1 = TimeZone.offset(from: "20201212111111.000+1234")
+    XCTAssertEqual(aheadMinsOff1, 45240)
+    let aheadMinsOff2 = TimeZone.offset(from: "20201212111111.000+12:34")
+    XCTAssertEqual(aheadMinsOff2, 45240)
+
+    let behindMinsOff1 = TimeZone.offset(from: "20201212111111.000-1234")
+    XCTAssertEqual(behindMinsOff1, -45240)
+    let behindMinsOff2 = TimeZone.offset(from: "20201212111111.000-12:34")
+    XCTAssertEqual(behindMinsOff2, -45240)
+
+    let aheadHrsOff = TimeZone.offset(from: "20201212111111.000+12")
+    XCTAssertEqual(aheadHrsOff, 43200)
+
+    let behindHrsOff = TimeZone.offset(from: "20201212111111.000-12")
+    XCTAssertEqual(behindHrsOff, -43200)
+  }
+
+  func testParsingTimeZones() throws {
+
+    let noTZ = TimeZone.timeZone(from: "20201212111111.000")
+    XCTAssertNil(noTZ)
+
+    let utcTZ = TimeZone.timeZone(from: "20201212111111.000Z")
+    XCTAssertEqual(utcTZ?.secondsFromGMT(), 0)
+
+    let aheadSecsTZ1 = TimeZone.timeZone(from: "20201212111111.000+123456")
+    XCTAssertEqual(aheadSecsTZ1?.secondsFromGMT(), 45300)
+    let aheadSecsTZ2 = TimeZone.timeZone(from: "20201212111111.000+12:34:56")
+    XCTAssertEqual(aheadSecsTZ2?.secondsFromGMT(), 45300)
+
+    let behindSecsTZ1 = TimeZone.timeZone(from: "20201212111111.000-123456")
+    XCTAssertEqual(behindSecsTZ1?.secondsFromGMT(), -45300)
+    let behindSecsTZ2 = TimeZone.timeZone(from: "20201212111111.000-12:34:56")
+    XCTAssertEqual(behindSecsTZ2?.secondsFromGMT(), -45300)
+
+    let aheadMinsTZ1 = TimeZone.timeZone(from: "20201212111111.000+1234")
+    XCTAssertEqual(aheadMinsTZ1?.secondsFromGMT(), 45240)
+    let aheadMinsTZ2 = TimeZone.timeZone(from: "20201212111111.000+12:34")
+    XCTAssertEqual(aheadMinsTZ2?.secondsFromGMT(), 45240)
+
+    let behindMinsTZ1 = TimeZone.timeZone(from: "20201212111111.000-1234")
+    XCTAssertEqual(behindMinsTZ1?.secondsFromGMT(), -45240)
+    let behindMinsTZ2 = TimeZone.timeZone(from: "20201212111111.000-12:34")
+    XCTAssertEqual(behindMinsTZ2?.secondsFromGMT(), -45240)
+
+    let aheadHrsTZ = TimeZone.timeZone(from: "20201212111111.000+12")
+    XCTAssertEqual(aheadHrsTZ?.secondsFromGMT(), 43200)
+
+    let behindHrsTZ = TimeZone.timeZone(from: "20201212111111.000-12")
+    XCTAssertEqual(behindHrsTZ?.secondsFromGMT(), -43200)
+  }
+
+}


### PR DESCRIPTION
This replaces the use of `Foundation.Date` with a custom `ZonedDate` type. This allows supporting properly reading/writing GeneralizedTime values with a specific time zone.

This also uses specialized parsers for reading GeneralizedTime values that properly allows reading values with optional fractional seconds and optional zones; fixing #13.

This will require a major version bump as it changes the public API.