### PR TITLE
Share parsing of ISO8601 dates with optional suffixes

### DIFF
--- a/Sources/PotentCodables/Dates.swift
+++ b/Sources/PotentCodables/Dates.swift
@@ -1,0 +1,81 @@
+//
+//  Dates.swift
+//  PotentCodables
+//
+//  Created by Kevin Wooten on 9/12/21.
+//
+
+import Foundation
+
+public struct ISO8601SuffixedDateFormatter {
+
+  private let noSuffixes: DateFormatter
+  private let zoneSuffix: DateFormatter
+  private let fractionalSecondsSuffix: DateFormatter
+  private let zoneAndFractionalSecondsSuffixes: DateFormatter
+
+  public init(basePattern: String) {
+    noSuffixes = {
+      let formatter = DateFormatter()
+      formatter.calendar = Calendar(identifier: .iso8601)
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = TimeZone(secondsFromGMT: 0)
+      formatter.dateFormat = basePattern
+      return formatter
+    }()
+
+    zoneSuffix = {
+      let formatter = DateFormatter()
+      formatter.calendar = Calendar(identifier: .iso8601)
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = TimeZone(secondsFromGMT: 0)
+      formatter.dateFormat = "\(basePattern)XXXX"
+      return formatter
+    }()
+
+    fractionalSecondsSuffix = {
+      let formatter = DateFormatter()
+      formatter.calendar = Calendar(identifier: .iso8601)
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = TimeZone(secondsFromGMT: 0)
+      formatter.dateFormat = "\(basePattern).S"
+      return formatter
+    }()
+
+    zoneAndFractionalSecondsSuffixes = {
+      let formatter = DateFormatter()
+      formatter.calendar = Calendar(identifier: .iso8601)
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = TimeZone(secondsFromGMT: 0)
+      formatter.dateFormat = "\(basePattern).SXXXX"
+      return formatter
+    }()
+  }
+
+  public func date(from string: String) -> ZonedDate? {
+    let parsedDate: Date?
+    if string.hasFractionalSeconds && string.hasZone {
+      parsedDate = zoneAndFractionalSecondsSuffixes.date(from: string)
+    }
+    else if string.hasFractionalSeconds {
+      parsedDate = fractionalSecondsSuffix.date(from: string)
+    }
+    else if string.hasZone {
+      parsedDate = zoneSuffix.date(from: string)
+    }
+    else {
+      parsedDate = noSuffixes.date(from: string)
+    }
+    guard parsedDate != nil else {
+      return nil
+    }
+    let parsedTimeZone = TimeZone.timeZone(from: string) ?? .current
+    return ZonedDate(date: parsedDate!, timeZone: parsedTimeZone)
+  }
+
+}
+
+private extension String {
+  var hasFractionalSeconds: Bool { contains(".") }
+  var hasZone: Bool { contains("+") || contains("-") || contains("Z") }
+}

--- a/Sources/PotentJSON/JSONDecoder.swift
+++ b/Sources/PotentJSON/JSONDecoder.swift
@@ -287,11 +287,11 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
 
     case .iso8601:
       let string = try unbox(value, as: String.self, decoder: decoder)!
-      guard let date = _iso8601Formatter.date(from: string) else {
+      guard let zonedDate = _iso8601Formatter.date(from: string) else {
         throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath,
                                                 debugDescription: "Expected date string to be ISO8601-formatted."))
       }
-      return date
+      return zonedDate.utcDate
 
     case .formatted(let formatter):
       let string = try unbox(value, as: String.self, decoder: decoder)!
@@ -351,14 +351,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
 }
 
 
-private let _iso8601Formatter: DateFormatter = {
-  let formatter = DateFormatter()
-  formatter.calendar = Calendar(identifier: .iso8601)
-  formatter.locale = Locale(identifier: "en_US_POSIX")
-  formatter.timeZone = TimeZone(secondsFromGMT: 0)
-  formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-  return formatter
-}()
+private let _iso8601Formatter = ISO8601SuffixedDateFormatter(basePattern: "yyyy-MM-dd'T'HH:mm:ss")
 
 
 #if canImport(Combine)

--- a/Sources/PotentYAML/YAMLDecoder.swift
+++ b/Sources/PotentYAML/YAMLDecoder.swift
@@ -300,11 +300,11 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
       
     case .iso8601:
       let string = try unbox(value, as: String.self, decoder: decoder)!
-      guard let date = _iso8601Formatter.date(from: string) else {
+      guard let zonedDate = _iso8601Formatter.date(from: string) else {
         throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath,
                                                 debugDescription: "Expected date string to be ISO8601-formatted."))
       }
-      return date
+      return zonedDate.utcDate
       
     case .formatted(let formatter):
       let string = try unbox(value, as: String.self, decoder: decoder)!
@@ -372,14 +372,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
 }
 
 
-private let _iso8601Formatter: DateFormatter = {
-  let formatter = DateFormatter()
-  formatter.calendar = Calendar(identifier: .iso8601)
-  formatter.locale = Locale(identifier: "en_US_POSIX")
-  formatter.timeZone = TimeZone(secondsFromGMT: 0)
-  formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-  return formatter
-}()
+private let _iso8601Formatter = ISO8601SuffixedDateFormatter(basePattern: "yyyy-MM-dd'T'HH:mm:ss")
 
 
 #if canImport(Combine)


### PR DESCRIPTION
Centralizes and shares the dynamic parsing of ISO8601 style parsing allowing options fractional seconds and/or time zone. JSON, YAML & ANS.1 now use the same logic when parsing these style dates.