### PR TITLE
YAML updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The package provides multiple libraries corresponding to the core library and ea
 * `PotentJSON` provides JSON format support
 * `PotentCBOR` provide CBOR format support
 * `PotentASN1` provides ASN.1 support
+* `PotentYAML` provides YAML 1.2 support
 
 
 ## Usage
@@ -43,6 +44,11 @@ For example encoding to CBOR is essentially the same as encoding with Swift's st
 let data = try CBOREncoder.default.encode(myValue)
 ```
 #### Provided Formats
+
+- YAML - `YAMLEncoder`/`YAMLDecoder` or `YAML.Encoder`/`YAML.Decoder`
+  A conformant [YAML 1.2](https://yaml.org/spec/1.2.1/) implementation implemented via
+  [libfyaml](https://github.com/pantoniou/libfyaml). Due to the fact that JSON is a subset of YAML 1.2 the decoder
+  can parse and decode YAML & JSON documents.
 
 - JSON - `JSONEncoder`/`JSONDecoder` or `JSON.Encoder`/`JSON.Decoder`
   A conformant [JSON](https://tools.ietf.org/html/rfc8259) implementation that is a drop-in replacement for Swift's JSON encoder and

--- a/Sources/Cfyaml/lib/fy-token.c
+++ b/Sources/Cfyaml/lib/fy-token.c
@@ -433,7 +433,7 @@ struct fy_token *fy_token_vcreate(enum fy_token_type type, va_list ap)
 		break;
 	case FYTT_SCALAR:
 		fyt->scalar.style = va_arg(ap, enum fy_scalar_style);
-		if ((unsigned int)fyt->scalar.style >= FYSS_MAX)
+		if (fyt->scalar.style >= FYSS_MAX)
 			goto err_out;
 		break;
 	case FYTT_TAG:

--- a/Sources/PotentYAML/YAML.swift
+++ b/Sources/PotentYAML/YAML.swift
@@ -132,6 +132,7 @@ public enum YAML {
   }
   
   public enum StringStyle : Int32 {
+    case any = -1
     case plain = 0
     case singleQuoted = 1
     case doubleQuoted = 2
@@ -140,6 +141,7 @@ public enum YAML {
   }
   
   public enum CollectionStyle : Int32 {
+    case any
     case flow
     case block
   }
@@ -358,7 +360,7 @@ extension YAML : ExpressibleByFloatLiteral {
 extension YAML : ExpressibleByStringLiteral {
   
   public init(stringLiteral value: StringLiteralType) {
-    self = .string(value, style: .doubleQuoted, tag: nil, anchor: nil)
+    self = .string(value, style: .any, tag: nil, anchor: nil)
   }
   
 }
@@ -366,7 +368,7 @@ extension YAML : ExpressibleByStringLiteral {
 extension YAML : ExpressibleByArrayLiteral {
   
   public init(arrayLiteral elements: YAML...) {
-    self = .sequence(elements, style: .block, tag: nil, anchor: nil)    
+    self = .sequence(elements, style: .any, tag: nil, anchor: nil)
   }
   
 }
@@ -375,8 +377,40 @@ extension YAML : ExpressibleByArrayLiteral {
 extension YAML : ExpressibleByDictionaryLiteral {
   
   public init(dictionaryLiteral elements: (YAML, YAML)...) {
-    self = .mapping(elements.map { MapEntry(key: $0, value: $1) }, style: .block, tag: nil, anchor: nil)    
+    self = .mapping(elements.map { MapEntry(key: $0, value: $1) }, style: .any, tag: nil, anchor: nil)    
   }
   
 }
 
+
+/**
+ * "Stable" encoding of YAML to text
+ *
+ * Encodes values in a stable (aka repeatable) manner making it
+ * easy to compare different complex values that have been encoded
+ * to text
+ **/
+extension YAML {
+
+  public var stableText: String {
+    var output = ""
+    do {
+      try YAMLWriter.write([self], sortedKeys: true) { output += $0 ?? "" }
+    }
+    catch {
+      output = "Invalid YAML: \(error)"
+    }
+    return output
+  }
+
+}
+
+
+/// Make encoders/decoders available in JSON namespace
+///
+public extension YAML {
+
+  typealias Encoder = YAMLEncoder
+  typealias Decoder = YAMLDecoder
+
+}

--- a/Sources/PotentYAML/YAMLEncoder.swift
+++ b/Sources/PotentYAML/YAMLEncoder.swift
@@ -121,8 +121,8 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
   public typealias Encoder = InternalValueEncoder<Value, Self>
   public typealias State = Void
   
-  public static var emptyKeyedContainer = YAML.mapping([], style: .block, tag: nil, anchor: nil)
-  public static var emptyUnkeyedContainer = YAML.sequence([], style: .block, tag: nil, anchor: nil)
+  public static var emptyKeyedContainer = YAML.mapping([], style: .any, tag: nil, anchor: nil)
+  public static var emptyUnkeyedContainer = YAML.sequence([], style: .any, tag: nil, anchor: nil)
   
   public struct Options: InternalEncoderOptions {
     public let dateEncodingStrategy: YAMLEncoder.DateEncodingStrategy
@@ -145,9 +145,9 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
   public static func box(_ value: UInt16, encoder: Encoder) throws -> YAML { return .integer(.init(value.description), anchor: nil) }
   public static func box(_ value: UInt32, encoder: Encoder) throws -> YAML { return .integer(.init(value.description), anchor: nil) }
   public static func box(_ value: UInt64, encoder: Encoder) throws -> YAML { return .integer(.init(value.description), anchor: nil) }
-  public static func box(_ value: String, encoder: Encoder) throws -> YAML { return .string(value, style: .doubleQuoted, tag: nil, anchor: nil) }
-  public static func box(_ value: URL, encoder: Encoder) throws -> YAML { return .string(value.absoluteString, style: .doubleQuoted, tag: nil, anchor: nil) }
-  public static func box(_ value: UUID, encoder: Encoder) throws -> YAML { return .string(value.uuidString, style: .doubleQuoted, tag: nil, anchor: nil) }
+  public static func box(_ value: String, encoder: Encoder) throws -> YAML { return .string(value, style: .any, tag: nil, anchor: nil) }
+  public static func box(_ value: URL, encoder: Encoder) throws -> YAML { return .string(value.absoluteString, style: .any, tag: nil, anchor: nil) }
+  public static func box(_ value: UUID, encoder: Encoder) throws -> YAML { return .string(value.uuidString, style: .any, tag: nil, anchor: nil) }
   
   public static func box(_ float: Float, encoder: Encoder) throws -> YAML {
     guard !float.isInfinite, !float.isNaN else {
@@ -158,13 +158,13 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
       }
       
       if float == Float.infinity {
-        return .string(posInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(posInfString, style: .any, tag: nil, anchor: nil)
       }
       else if float == -Float.infinity {
-        return .string(negInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(negInfString, style: .any, tag: nil, anchor: nil)
       }
       else {
-        return .string(nanString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(nanString, style: .any, tag: nil, anchor: nil)
       }
     }
     
@@ -180,13 +180,13 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
       }
       
       if double == Double.infinity {
-        return .string(posInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(posInfString, style: .any, tag: nil, anchor: nil)
       }
       else if double == -Double.infinity {
-        return .string(negInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(negInfString, style: .any, tag: nil, anchor: nil)
       }
       else {
-        return .string(nanString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(nanString, style: .any, tag: nil, anchor: nil)
       }
     }
     
@@ -202,13 +202,13 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
       }
       
       if decimal.isInfinite, decimal.sign == .plus {
-        return .string(posInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(posInfString, style: .any, tag: nil, anchor: nil)
       }
       else if decimal.isInfinite, decimal.sign == .minus {
-        return .string(negInfString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(negInfString, style: .any, tag: nil, anchor: nil)
       }
       else {
-        return .string(nanString, style: .doubleQuoted, tag: nil, anchor: nil)
+        return .string(nanString, style: .any, tag: nil, anchor: nil)
       }
     }
     
@@ -224,7 +224,7 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
       return try encoder.subEncode { try value.encode(to: $0) } ?? emptyKeyedContainer
       
     case .base64:
-      return .string(value.base64EncodedString(), style: .plain, tag: nil, anchor: nil)
+      return .string(value.base64EncodedString(), style: .any, tag: nil, anchor: nil)
       
     case .custom(let closure):
       return try encoder.subEncode { try closure(value, $0) } ?? emptyKeyedContainer
@@ -243,10 +243,10 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
       return .integer(.init((1000.0 * value.timeIntervalSince1970).description), anchor: nil)
       
     case .iso8601:
-      return .string(_iso8601Formatter.string(from: value), style: .doubleQuoted, tag: nil, anchor: nil)
+      return .string(_iso8601Formatter.string(from: value), style: .any, tag: nil, anchor: nil)
       
     case .formatted(let formatter):
-      return .string(formatter.string(from: value), style: .doubleQuoted, tag: nil, anchor: nil)
+      return .string(formatter.string(from: value), style: .any, tag: nil, anchor: nil)
       
     case .custom(let closure):
       return try encoder.subEncode { try closure(value, $0) } ?? emptyKeyedContainer
@@ -254,11 +254,11 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
   }
   
   public static func unkeyedValuesToValue(_ values: [YAML], encoder: Encoder) -> YAML {
-    return .sequence(values, style: .block, tag: nil, anchor: nil)
+    return .sequence(values, style: .any, tag: nil, anchor: nil)
   }
   
   public static func keyedValuesToValue(_ values: [String: YAML], encoder: Encoder) -> YAML {
-    return .mapping(values.map { (.init(key: .string($0.key, style: .plain, tag: nil, anchor: nil), value: $0.value)) }, style: .block, tag: nil, anchor: nil)
+    return .mapping(values.map { (.init(key: .string($0.key, style: .any, tag: nil, anchor: nil), value: $0.value)) }, style: .any, tag: nil, anchor: nil)
   }
   
   public static func data(from value: YAML, options: Options) throws -> Data {

--- a/Sources/PotentYAML/YAMLSerialization.swift
+++ b/Sources/PotentYAML/YAMLSerialization.swift
@@ -32,7 +32,7 @@ public struct YAMLSerialization {
     if yamls.count == 1 {
       return yamls[0]
     }
-    return .sequence(yamls, style: .block, tag: nil, anchor: nil)
+    return .sequence(yamls, style: .any, tag: nil, anchor: nil)
   }
 
   


### PR DESCRIPTION
* Use `any` style when building/encoding YAML objects. Allowing the emitter to choose the best style to output scalars and collections.
* Implement `stableText` for YAML
* Fix YAML document event creation
* Add missing `Encoder`/`Decoder` declarations for `YAML`
* Update README with YAML feature