### PR TITLE
Ordered objects for JSON & maps for CBOR, and type aliases for container types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "19f5e8a48be155e34abb98a2bcf4a343316f0343",
-          "version": "5.0.0"
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
         }
       },
       {
-        "package": "OrderedDictionary",
-        "repositoryURL": "https://github.com/lukaskubanek/OrderedDictionary.git",
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "69ed90dcfc8cf380c81fd16c7a6d699e74870ad9",
-          "version": "2.3.0"
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,8 +26,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.0.0"),
-    .package(url: "https://github.com/lukaskubanek/OrderedDictionary.git", from: "2.2.2")
+    .package(url: "https://github.com/attaswift/BigInt.git", .upToNextMinor(from: "5.3.0")),
+    .package(url: "https://github.com/apple/swift-collections.git", .upToNextMinor(from: "1.0.4"))
   ],
   targets: [
     .target(
@@ -35,15 +35,25 @@ let package = Package(
     ),
     .target(
       name: "PotentJSON",
-      dependencies: ["PotentCodables"]
+      dependencies: [
+        "PotentCodables",
+        .product(name: "Collections", package: "swift-collections")
+      ]
     ),
     .target(
       name: "PotentCBOR",
-      dependencies: ["PotentCodables"]
+      dependencies: [
+        "PotentCodables",
+        .product(name: "Collections", package: "swift-collections")
+      ]
     ),
     .target(
       name: "PotentASN1",
-      dependencies: ["PotentCodables", "BigInt", "OrderedDictionary"]
+      dependencies: [
+        "PotentCodables",
+        "BigInt",
+        .product(name: "Collections", package: "swift-collections")
+      ]
     ),
     .target(    
       name: "Cfyaml",

--- a/Sources/PotentASN1/BigInts.swift
+++ b/Sources/PotentASN1/BigInts.swift
@@ -11,6 +11,7 @@
 import BigInt
 import Foundation
 
+
 public extension BigUInt {
 
   var integerValue: Int? {

--- a/Sources/PotentASN1/Schema.swift
+++ b/Sources/PotentASN1/Schema.swift
@@ -10,7 +10,7 @@
 
 import BigInt
 import Foundation
-import OrderedDictionary
+import OrderedCollections
 import PotentCodables
 
 

--- a/Sources/PotentCBOR/CBOR.swift
+++ b/Sources/PotentCBOR/CBOR.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import OrderedCollections
 import PotentCodables
 
 
@@ -43,12 +44,15 @@ public indirect enum CBOR: Equatable, Hashable {
     }
   }
 
+  public typealias Array = [CBOR]
+  public typealias Map = OrderedDictionary<CBOR, CBOR>
+
   case unsignedInt(UInt64)
   case negativeInt(UInt64)
   case byteString(Data)
   case utf8String(String)
-  case array([CBOR])
-  case map([CBOR: CBOR])
+  case array(Array)
+  case map(Map)
   case tagged(Tag, CBOR)
   case simple(UInt8)
   case boolean(Bool)
@@ -78,12 +82,12 @@ public indirect enum CBOR: Equatable, Hashable {
     return string
   }
 
-  public var arrayValue: [CBOR]? {
+  public var arrayValue: Array? {
     guard case .array(let array) = untagged else { return nil }
     return array
   }
 
-  public var mapValue: [CBOR: CBOR]? {
+  public var mapValue: Map? {
     guard case .map(let map) = untagged else { return nil }
     return map
   }
@@ -243,11 +247,7 @@ extension CBOR: ExpressibleByNilLiteral, ExpressibleByIntegerLiteral, Expressibl
   }
 
   public init(dictionaryLiteral elements: (CBOR, CBOR)...) {
-    var result = [CBOR: CBOR]()
-    for (key, value) in elements {
-      result[key] = value
-    }
-    self = .map(result)
+    self = .map(Map(uniqueKeysWithValues: elements))
   }
 
   public init(booleanLiteral value: Bool) {
@@ -304,7 +304,7 @@ extension CBOR: Value {
     case .float(let value): return value
     case .half(let value): return value.floatValue
     case .double(let value): return value
-    case .array(let value): return Array(value.map(\.unwrapped))
+    case .array(let value): return Swift.Array(value.map(\.unwrapped))
     case .map(let value): return Dictionary(uniqueKeysWithValues: value.map { key, value in
         (key.unwrapped as? AnyHashable, value.unwrapped)
       })

--- a/Sources/PotentCBOR/CBORDecoder.swift
+++ b/Sources/PotentCBOR/CBORDecoder.swift
@@ -358,7 +358,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     return try mapToKeyedValues(map, decoder: decoder)
   }
 
-  public static func mapToKeyedValues(_ map: [CBOR: CBOR], decoder: Decoder) throws -> [String: CBOR] {
+  public static func mapToKeyedValues(_ map: CBOR.Map, decoder: Decoder) throws -> [String: CBOR] {
     return try Dictionary(
       map.compactMap { key, value in
         switch key.untagged {

--- a/Sources/PotentCBOR/CBOREncoder.swift
+++ b/Sources/PotentCBOR/CBOREncoder.swift
@@ -109,7 +109,7 @@ public struct CBOREncoderTransform: InternalEncoderTransform, InternalValueSeria
   }
 
   public static func keyedValuesToValue(_ values: [String: CBOR], encoder: Encoder) -> CBOR {
-    return .map(Dictionary(uniqueKeysWithValues: values.map { key, value in (CBOR(key), value) }))
+    return .map(CBOR.Map(uniqueKeysWithValues: values.map { key, value in (CBOR(key), value) }))
   }
 
   public static func data(from value: CBOR, options: Options) throws -> Data {

--- a/Sources/PotentCBOR/CBORReader.swift
+++ b/Sources/PotentCBOR/CBORReader.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 
+
 private typealias CBORError = CBORSerialization.Error
 
 public struct CBORReader {
@@ -61,8 +62,8 @@ public struct CBORReader {
   ///     including `.invalidBreak` if a break indicator is encountered in
   ///     an item slot
   ///     - `Swift.Error`: If any I/O error occurs
-  public func decodeItems(count: Int) throws -> [CBOR] {
-    var result: [CBOR] = []
+  public func decodeItems(count: Int) throws -> CBOR.Array {
+    var result: CBOR.Array = []
     for _ in 0 ..< count {
       let item = try decodeRequiredItem()
       result.append(item)
@@ -77,8 +78,8 @@ public struct CBORReader {
   /// - Throws:
   ///     - `CBORSerialization.Error`: If corrupted data is encountered
   ///     - `Swift.Error`: If any I/O error occurs
-  public func decodeItemsUntilBreak() throws -> [CBOR] {
-    var result: [CBOR] = []
+  public func decodeItemsUntilBreak() throws -> CBOR.Array {
+    var result: CBOR.Array = []
     while let item = try decodeItem() {
       result.append(item)
     }
@@ -93,8 +94,8 @@ public struct CBORReader {
   ///     including `.invalidBreak` if a break indicator is encountered in
   ///     the either the key or value slot
   ///     - `Swift.Error`: If any I/O error occurs
-  public func decodeItemPairs(count: Int) throws -> [CBOR: CBOR] {
-    var result: [CBOR: CBOR] = [:]
+  public func decodeItemPairs(count: Int) throws -> CBOR.Map {
+    var result: CBOR.Map = [:]
     for _ in 0 ..< count {
       let key = try decodeRequiredItem()
       let val = try decodeRequiredItem()
@@ -112,8 +113,8 @@ public struct CBORReader {
   ///     including `.invalidBreak` if a break indicator is encountered in
   ///     the value slot
   ///     - `Swift.Error`: If any I/O error occurs
-  public func decodeItemPairsUntilBreak() throws -> [CBOR: CBOR] {
-    var result: [CBOR: CBOR] = [:]
+  public func decodeItemPairsUntilBreak() throws -> CBOR.Map {
+    var result: CBOR.Map = [:]
     while let key = try decodeItem() {
       let val = try decodeRequiredItem()
       result[key] = val

--- a/Sources/PotentCBOR/CBORWriter.swift
+++ b/Sources/PotentCBOR/CBORWriter.swift
@@ -174,7 +174,7 @@ public struct CBORWriter {
   ///
   /// - Throws:
   ///     - `Swift.Error`: If any I/O error occurs
-  public func encodeArray(_ array: [CBOR]) throws {
+  public func encodeArray(_ array: CBOR.Array) throws {
     try encodeInt(array.count, majorType: 0b100)
     try encodeArrayChunk(array)
   }
@@ -187,7 +187,7 @@ public struct CBORWriter {
   ///
   /// - Throws:
   ///     - `Swift.Error`: If any I/O error occurs
-  public func encodeArrayChunk(_ chunk: [CBOR]) throws {
+  public func encodeArrayChunk(_ chunk: CBOR.Array) throws {
     for item in chunk {
       try encode(item)
     }
@@ -199,7 +199,7 @@ public struct CBORWriter {
   ///
   /// - Throws:
   ///     - `Swift.Error`: If any I/O error occurs
-  public func encodeMap(_ map: [CBOR: CBOR]) throws {
+  public func encodeMap(_ map: CBOR.Map) throws {
     try encodeInt(map.count, majorType: 0b101)
     try encodeMapChunk(map)
   }
@@ -212,7 +212,7 @@ public struct CBORWriter {
   ///
   /// - Throws:
   ///     - `Swift.Error`: If any I/O error occurs
-  public func encodeMapChunk(_ map: [CBOR: CBOR]) throws {
+  public func encodeMapChunk(_ map: CBOR.Map) throws {
     for (key, value) in map {
       try encode(key)
       try encode(value)

--- a/Sources/PotentCodables/AnyValue/AnyValue.swift
+++ b/Sources/PotentCodables/AnyValue/AnyValue.swift
@@ -199,7 +199,7 @@ extension AnyValue: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, Expres
   public typealias Value = AnyValue
 
   public init(dictionaryLiteral elements: (Key, Value)...) {
-    self = .dictionary(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+    self = .dictionary(Dictionary(uniqueKeysWithValues: elements))
   }
 
 }

--- a/Sources/PotentJSON/JSONDecoder.swift
+++ b/Sources/PotentJSON/JSONDecoder.swift
@@ -347,7 +347,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
 
   public static func valueToKeyedValues(_ value: JSON, decoder: Decoder) throws -> [String: JSON]? {
     guard case .object(let dict) = value else { return nil }
-    return dict
+    return Dictionary(uniqueKeysWithValues: Array(dict.elements))
   }
 
   public static func value(from data: Data, options: Options) throws -> JSON {

--- a/Sources/PotentJSON/JSONEncoder.swift
+++ b/Sources/PotentJSON/JSONEncoder.swift
@@ -269,7 +269,7 @@ public struct JSONEncoderTransform: InternalEncoderTransform, InternalValueSeria
   }
 
   public static func keyedValuesToValue(_ values: [String: JSON], encoder: Encoder) -> JSON {
-    return .object(values)
+    return .object(JSON.Object(uniqueKeysWithValues: values))
   }
 
   public static func data(from value: JSON, options: Options) throws -> Data {

--- a/Sources/PotentJSON/JSONReader.swift
+++ b/Sources/PotentJSON/JSONReader.swift
@@ -392,12 +392,12 @@ struct JSONReader {
 
   // MARK: - Object parsing
 
-  func parseObject(_ input: Index, options opt: JSONSerialization.ReadingOptions) throws -> ([String: JSON], Index)? {
+  func parseObject(_ input: Index, options opt: JSONSerialization.ReadingOptions) throws -> (JSON.Object, Index)? {
     guard let beginIndex = try consumeStructure(Structure.beginObject, input: input) else {
       return nil
     }
     var index = beginIndex
-    var output: [String: JSON] = [:]
+    var output: JSON.Object = [:]
     while true {
       if let finalIndex = try consumeStructure(Structure.endObject, input: index) {
         return (output, finalIndex)
@@ -440,12 +440,12 @@ struct JSONReader {
 
   // MARK: - Array parsing
 
-  func parseArray(_ input: Index, options opt: JSONSerialization.ReadingOptions) throws -> ([JSON], Index)? {
+  func parseArray(_ input: Index, options opt: JSONSerialization.ReadingOptions) throws -> (JSON.Array, Index)? {
     guard let beginIndex = try consumeStructure(Structure.beginArray, input: input) else {
       return nil
     }
     var index = beginIndex
-    var output: [JSON] = []
+    var output: JSON.Array = []
     while true {
       if let finalIndex = try consumeStructure(Structure.endArray, input: index) {
         return (output, finalIndex)

--- a/Sources/PotentJSON/JSONWriter.swift
+++ b/Sources/PotentJSON/JSONWriter.swift
@@ -93,7 +93,7 @@ struct JSONWriter {
     writer(str)
   }
 
-  mutating func serializeArray(_ array: [JSON]) throws {
+  mutating func serializeArray(_ array: JSON.Array) throws {
     writer("[")
     if pretty {
       writer("\n")
@@ -121,7 +121,7 @@ struct JSONWriter {
     writer("]")
   }
 
-  mutating func serializeDictionary(_ dict: [String: JSON]) throws {
+  mutating func serializeDictionary(_ dict: JSON.Object) throws {
     writer("{")
     if pretty {
       writer("\n")

--- a/Sources/PotentYAML/YAML.swift
+++ b/Sources/PotentYAML/YAML.swift
@@ -134,6 +134,15 @@ public enum YAML {
     }
   }
 
+  public typealias Array = [YAML]
+
+  public struct MappingEntry: Equatable, Hashable {
+    var key: YAML
+    var value: YAML
+  }
+
+  public typealias Mapping = [MappingEntry]
+
   public enum StringStyle: Int32 {
     case any = -1
     case plain = 0
@@ -149,18 +158,13 @@ public enum YAML {
     case block
   }
 
-  public struct MapEntry: Equatable, Hashable {
-    let key: YAML
-    let value: YAML
-  }
-
   case null(anchor: Anchor?)
   case string(String, style: StringStyle, tag: Tag?, anchor: Anchor?)
   case integer(Number, anchor: Anchor?)
   case float(Number, anchor: Anchor?)
   case bool(Bool, anchor: Anchor?)
   case sequence([YAML], style: CollectionStyle, tag: Tag?, anchor: Anchor?)
-  case mapping([MapEntry], style: CollectionStyle, tag: Tag?, anchor: Anchor?)
+  case mapping(Mapping, style: CollectionStyle, tag: Tag?, anchor: Anchor?)
   case alias(String)
 
   public var isNull: Bool {
@@ -224,12 +228,12 @@ public enum YAML {
     return value
   }
 
-  public var sequenceValue: [YAML]? {
+  public var sequenceValue: Array? {
     guard case .sequence(let value, _, _, _) = self else { return nil }
     return value
   }
 
-  public var mappingValue: [YAML.MapEntry]? {
+  public var mappingValue: Mapping? {
     guard case .mapping(let value, _, _, _) = self else { return nil }
     return value
   }
@@ -320,7 +324,7 @@ extension YAML: Value {
     case .string(let value, _, _, _): return value
     case .integer(let value, _): return value.numberValue
     case .float(let value, _): return value.numberValue
-    case .sequence(let value, _, _, _): return Array(value.map(\.unwrapped))
+    case .sequence(let value, _, _, _): return Swift.Array(value.map(\.unwrapped))
     case .mapping(let value, _, _, _): return Dictionary(uniqueKeysWithValues: value.map { entry in
         (entry.key.stringValue!, entry.value.unwrapped)
       })
@@ -382,7 +386,7 @@ extension YAML: ExpressibleByArrayLiteral {
 extension YAML: ExpressibleByDictionaryLiteral {
 
   public init(dictionaryLiteral elements: (YAML, YAML)...) {
-    self = .mapping(elements.map { MapEntry(key: $0, value: $1) }, style: .any, tag: nil, anchor: nil)
+    self = .mapping(elements.map { MappingEntry(key: $0, value: $1) }, style: .any, tag: nil, anchor: nil)
   }
 
 }

--- a/Sources/PotentYAML/YAMLReader.swift
+++ b/Sources/PotentYAML/YAMLReader.swift
@@ -13,7 +13,7 @@ import Foundation
 
 public enum YAMLReader {
 
-  public static func read(data: Data) throws -> [YAML] {
+  public static func read(data: Data) throws -> YAML.Array {
 
     var parseCfg = fy_parse_cfg(search_path: nil, flags: fy_parse_cfg_flags(rawValue: 0), userdata: nil, diag: nil)
 
@@ -35,9 +35,9 @@ public enum YAMLReader {
   }
 
 
-  static func stream(parser: Parser) throws -> [YAML] {
+  static func stream(parser: Parser) throws -> YAML.Array {
 
-    var documents: [YAML] = []
+    var documents: YAML.Array = []
 
     while true {
 
@@ -73,9 +73,9 @@ public enum YAMLReader {
   }
 
 
-  static func mapping(parser: Parser) throws -> [YAML.MapEntry] {
+  static func mapping(parser: Parser) throws -> YAML.Mapping {
 
-    var result: [YAML.MapEntry] = []
+    var result: YAML.Mapping = []
 
     while true {
 
@@ -93,15 +93,15 @@ public enum YAMLReader {
 
       let val = try value(event: valEvent, parser: parser)
 
-      result.append(YAML.MapEntry(key: key, value: val))
+      result.append(YAML.Mapping.Element(key: key, value: val))
     }
 
   }
 
 
-  static func sequence(parser: Parser) throws -> [YAML] {
+  static func sequence(parser: Parser) throws -> YAML.Array {
 
-    var result: [YAML] = []
+    var result: YAML.Array = []
 
     while true {
 

--- a/Sources/PotentYAML/YAMLWriter.swift
+++ b/Sources/PotentYAML/YAMLWriter.swift
@@ -20,7 +20,7 @@ struct YAMLWriter {
 
   typealias Writer = (String?) -> Void
 
-  public static func write(_ documents: [YAML], sortedKeys: Bool = false, writer: @escaping Writer) throws {
+  public static func write(_ documents: YAML.Array, sortedKeys: Bool = false, writer: @escaping Writer) throws {
 
     func output(
       emitter: OpaquePointer?,

--- a/Tests/CBORTests.swift
+++ b/Tests/CBORTests.swift
@@ -61,7 +61,7 @@ class CBORTests: XCTestCase {
       ],
     ]
 
-    let nestedMap: [CBOR: CBOR] = [
+    let nestedMap: CBOR.Map = [
       "joe": "schmoe",
       "age": 56,
     ]
@@ -69,4 +69,27 @@ class CBORTests: XCTestCase {
     cbor["tags"]?[2] = CBOR.map(nestedMap)
     XCTAssertEqual(cbor["tags"]?[2], CBOR.map(nestedMap))
   }
+
+  func testMapKeySerializationOrder() throws {
+
+    let cbor = try CBORSerialization.data(with: [
+      "c": 1,
+      "a": 2,
+      "b": 3,
+    ])
+
+    XCTAssertEqual(cbor, Data([0xA3, 0x61, 0x63, 0x01, 0x61, 0x61, 0x02, 0x61, 0x62, 0x03]))
+  }
+
+  func testMapKeyDeserializationOrder() throws {
+
+    let map: CBOR = [
+      "c": 1,
+      "a": 2,
+      "b": 3,
+    ]
+
+    XCTAssertEqual(map, try CBORSerialization.cbor(from: Data([0xA3, 0x61, 0x63, 0x01, 0x61, 0x61, 0x02, 0x61, 0x62, 0x03])))
+  }
+
 }

--- a/Tests/JSONTests.swift
+++ b/Tests/JSONTests.swift
@@ -110,6 +110,39 @@ class JSONTests: XCTestCase {
     XCTAssertEqual(json, values.stableText)
   }
 
+  func testObjectKeySerializationExplicitOrder() throws {
+
+    let json = try JSONSerialization.string(from: [
+      "c": 1,
+      "a": 2,
+      "b": 3,
+    ])
+
+    XCTAssertEqual(json, #"{"c":1,"a":2,"b":3}"#)
+  }
+
+  func testObjectKeySerializationSortedOrder() throws {
+
+    let json = try JSONSerialization.string(from: [
+      "c": 1,
+      "a": 2,
+      "b": 3,
+    ], options: .sortedKeys)
+
+    XCTAssertEqual(json, #"{"a":2,"b":3,"c":1}"#)
+  }
+
+  func testObjectKeyDeserializationOrder() throws {
+
+    let object: JSON = [
+      "c": 1,
+      "a": 2,
+      "b": 3,
+    ]
+
+    XCTAssertEqual(object, try JSONSerialization.json(from: #"{"c":1,"a":2,"b":3}"#))
+  }
+
 }
 
 


### PR DESCRIPTION
* JSON `object` & CBOR `map` are now ordered dictionaries.
* * `JSON.description` no longer sorts keys and is now stable; `stableText` has been removed in favor of `description`.
* Uses type aliases for JSON, YAML & CBOR element types and use them throughout the code.
* Switches to Apple’s `swift-collections` for `OrderedDictionary`.
* `ValueDecoder` now throws a descriptive error when presented with non-unique dictionaries after conversion.