### PR TITLE
Use `box`ing when encoding AnyValues

### DIFF
--- a/Sources/PotentCBOR/CBOREncoder.swift
+++ b/Sources/PotentCBOR/CBOREncoder.swift
@@ -197,11 +197,11 @@ public struct CBOREncoderTransform: InternalEncoderTransform, InternalValueSeria
 
     switch value {
     case .nil:
-      return .null
+      return try boxNil(encoder: encoder)
     case .bool(let value):
-      return .boolean(value)
+      return try box(value, encoder: encoder)
     case .string(let value):
-      return .utf8String(value)
+      return try box(value, encoder: encoder)
     case .int8(let value):
       return try box(value, encoder: encoder)
     case .int16(let value):

--- a/Sources/PotentJSON/JSONEncoder.swift
+++ b/Sources/PotentJSON/JSONEncoder.swift
@@ -363,47 +363,47 @@ public struct JSONEncoderTransform: InternalEncoderTransform, InternalValueSeria
 
     switch value {
     case .nil:
-      return .null
+      return try boxNil(encoder: encoder)
     case .bool(let value):
-      return .bool(value)
+      return try box(value, encoder: encoder)
     case .int8(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .int16(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .int32(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .int64(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .integer(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .uint8(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .uint16(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .uint32(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .uint64(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .unsignedInteger(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .float16(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .float(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .double(let value):
-      return .number(JSON.Number(value))
+      return try box(value, encoder: encoder)
     case .decimal(let value):
-      return .number(JSON.Number(value.description, isInteger: false, isNegative: value < 0))
+      return try box(value, encoder: encoder)
     case .string(let value):
-      return .string(value)
+      return try box(value, encoder: encoder)
     case .data(let value):
-      return .string(value.base64EncodedString())
+      return try box(value, encoder: encoder)
     case .url(let value):
-      return .string(value.absoluteString)
+      return try box(value, encoder: encoder)
     case .date(let value):
-      return .string(ZonedDate(date: value, timeZone: .utc).iso8601EncodedString())
+      return try box(value, encoder: encoder)
     case .uuid(let value):
-      return .string(value.uuidString)
+      return try box(value, encoder: encoder)
     case .array(let value):
       return .array(try value.map { try box($0, encoder: encoder) })
     case .dictionary(let value):

--- a/Sources/PotentYAML/YAMLEncoder.swift
+++ b/Sources/PotentYAML/YAMLEncoder.swift
@@ -286,7 +286,7 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
   public static func box(_ value: AnyValue, encoder: IVE) throws -> YAML {
     switch value {
     case .nil:
-      return .null(anchor: nil)
+      return try boxNil(encoder: encoder)
     case .bool(let value):
       return try box(value, encoder: encoder)
     case .int8(let value):

--- a/Tests/JSONAnyValueTests.swift
+++ b/Tests/JSONAnyValueTests.swift
@@ -134,7 +134,7 @@ class JSONAnyValueTests: XCTestCase {
       "data" : "QmluYXJ5IERhdGE=",
       "url" : "https://example.com/some/thing",
       "uuid" : "46076D06-86E8-4B3B-80EF-B24115D4C609",
-      "date" : "2001-01-15T06:56:07.890Z",
+      "date" : 1234567.89,
       "array" : [
         null,
         false,
@@ -185,7 +185,7 @@ class JSONAnyValueTests: XCTestCase {
     XCTAssertEqual(dstValue.data, .string(srcValue.data.dataValue!.base64EncodedString()))
     XCTAssertEqual(dstValue.url, .string(srcValue.url.urlValue!.absoluteString))
     XCTAssertEqual(dstValue.uuid, .string(srcValue.uuid.uuidValue!.uuidString))
-    XCTAssertEqual(dstValue.date.stringValue, ZonedDate(date: srcValue.date.dateValue!, timeZone: .utc).iso8601EncodedString())
+    XCTAssertEqual(dstValue.date, .double(1234567.89))
     XCTAssertEqual(dstValue.array, .array([nil, false, .int64(456), "a"]))
     XCTAssertEqual(dstValue.object, .dictionary(["c": .int64(1), "a": .int64(2), "d": .int64(3), "b": .int64(4)]))
     XCTAssertEqual(dstValue.intObject, .dictionary([.string("2"): "a", .string("1"): "b", .string("4"): "c", .string("3"): "d"]))


### PR DESCRIPTION
Ensures that date and data strategies are followed when these values.