### PR TITLE
Fix direct encoding/decoding of AnyValue.AnyDictionary

### DIFF
--- a/Sources/PotentASN1/ASN1Decoder.swift
+++ b/Sources/PotentASN1/ASN1Decoder.swift
@@ -130,6 +130,7 @@ public struct ASN1DecoderTransform: InternalDecoderTransform, InternalValueDeser
     BigInt.self,
     BigUInt.self,
     AnyValue.self,
+    AnyValue.AnyDictionary.self,
   ]
 
   public static func intercepts(_ type: Decodable.Type) -> Bool {
@@ -178,6 +179,9 @@ public struct ASN1DecoderTransform: InternalDecoderTransform, InternalValueDeser
     }
     else if interceptedType == AnyValue.self {
       return try unbox(value, as: AnyValue.self, decoder: decoder)
+    }
+    else if interceptedType == AnyValue.AnyDictionary.self {
+      return try unbox(value, as: AnyValue.AnyDictionary.self, decoder: decoder)
     }
     else {
       fatalError("type not valid for intercept")
@@ -608,6 +612,15 @@ public struct ASN1DecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       fatalError("unexpected value")
     }
+  }
+
+  public static func unbox(_ value: ASN1, as type: AnyValue.AnyDictionary.Type, decoder: IVD) throws -> AnyValue.AnyDictionary? {
+    guard let keyedValues = try valueToKeyedValues(value, decoder: decoder) else {
+      return nil
+    }
+    return AnyValue.AnyDictionary(
+      uniqueKeysWithValues: try keyedValues.map { (.string($0), try unbox($1, as: AnyValue.self, decoder: decoder)) }
+    )
   }
 
   public static func valueToUnkeyedValues(_ value: ASN1, decoder: IVD) throws -> UnkeyedValues? {

--- a/Sources/PotentASN1/ASN1Encoder.swift
+++ b/Sources/PotentASN1/ASN1Encoder.swift
@@ -124,6 +124,7 @@ public struct ASN1EncoderTransform: InternalEncoderTransform, InternalValueSeria
     BigInt.self,
     BigUInt.self,
     AnyValue.self,
+    AnyValue.AnyDictionary.self,
   ]
 
   public static func intercepts(_ type: Encodable.Type) -> Bool {
@@ -134,6 +135,9 @@ public struct ASN1EncoderTransform: InternalEncoderTransform, InternalValueSeria
     var value: Any? = value
     if let anyValue = value as? AnyValue {
       return try box(anyValue, encoder: encoder)
+    }
+    if let value = value as? AnyValue.AnyDictionary {
+      return try box(.dictionary(value), encoder: encoder)
     }
     if let uuid = value as? UUID {
       value = uuid.uuidString

--- a/Sources/PotentCBOR/CBOREncoder.swift
+++ b/Sources/PotentCBOR/CBOREncoder.swift
@@ -93,6 +93,7 @@ public struct CBOREncoderTransform: InternalEncoderTransform, InternalValueSeria
     BigInt.self,
     BigUInt.self,
     AnyValue.self,
+    AnyValue.AnyDictionary.self,
   ]
 
   public static func intercepts(_ type: Encodable.Type) -> Bool {
@@ -126,6 +127,9 @@ public struct CBOREncoderTransform: InternalEncoderTransform, InternalValueSeria
     }
     else if let value = value as? AnyValue {
       return try box(value, encoder: encoder)
+    }
+    else if let value = value as? AnyValue.AnyDictionary {
+      return try box(.dictionary(value), encoder: encoder)
     }
     fatalError("type not valid for intercept")
   }

--- a/Sources/PotentJSON/JSONEncoder.swift
+++ b/Sources/PotentJSON/JSONEncoder.swift
@@ -153,6 +153,7 @@ public struct JSONEncoderTransform: InternalEncoderTransform, InternalValueSeria
     BigInt.self,
     BigUInt.self,
     AnyValue.self,
+    AnyValue.AnyDictionary.self,
   ]
 
   public static func intercepts(_ type: Encodable.Type) -> Bool {
@@ -186,6 +187,9 @@ public struct JSONEncoderTransform: InternalEncoderTransform, InternalValueSeria
     }
     else if let value = value as? AnyValue {
       return try box(value, encoder: encoder)
+    }
+    else if let value = value as? AnyValue.AnyDictionary {
+      return try box(.dictionary(value), encoder: encoder)
     }
     fatalError("type not valid for intercept")
   }

--- a/Sources/PotentYAML/YAMLEncoder.swift
+++ b/Sources/PotentYAML/YAMLEncoder.swift
@@ -132,6 +132,7 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
     BigInt.self,
     BigUInt.self,
     AnyValue.self,
+    AnyValue.AnyDictionary.self,
   ]
 
   public static func intercepts(_ type: Encodable.Type) -> Bool {
@@ -165,6 +166,9 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
     }
     else if let value = value as? AnyValue {
       return try box(value, encoder: encoder)
+    }
+    else if let value = value as? AnyValue.AnyDictionary {
+      return try box(.dictionary(value), encoder: encoder)
     }
     fatalError("type not valid for intercept")
   }

--- a/Tests/ASN1DecoderTests.swift
+++ b/Tests/ASN1DecoderTests.swift
@@ -1189,4 +1189,17 @@ class ASN1DecoderTests: XCTestCase {
     )
   }
 
+  func testDecodeAnyDictionary() throws {
+
+    let asn1 = Data(hexEncoded: "300c020101020102020103020104")
+
+    let value = try ASN1.Decoder(schema: .sequence(["b": .integer(),
+                                                    "z": .integer(),
+                                                    "n": .integer(),
+                                                    "f": .integer()]))
+      .decode(AnyValue.AnyDictionary.self, from: asn1)
+
+    XCTAssertEqual(value, ["b": .integer(1), "z": .integer(2), "n": .integer(3), "f": .integer(4)])
+  }
+
 }

--- a/Tests/ASN1EncoderTests.swift
+++ b/Tests/ASN1EncoderTests.swift
@@ -369,4 +369,15 @@ class ASN1EncoderTests: XCTestCase {
     )
   }
 
+  func testEncodeAnyDictionary() throws {
+
+    let dict: AnyValue.AnyDictionary = ["b": 1, "z": 2, "n": 3, "f": 4]
+
+    let testASN1 = try ASN1.Encoder(schema: .sequence(["b": .integer(),
+                                                       "z": .integer(),
+                                                       "n": .integer(),
+                                                       "f": .integer()])).encode(dict)
+    XCTAssertEqual(testASN1.hexEncodedString(), "300c020101020102020103020104")
+  }
+
 }

--- a/Tests/CBORDecoderTests.swift
+++ b/Tests/CBORDecoderTests.swift
@@ -1435,4 +1435,12 @@ class CBORDecoderTests: XCTestCase {
     }
   }
 
+  func testDecodeAnyDictionary() throws {
+
+    XCTAssertEqual(try CBOR.Decoder.default.decode(AnyValue.AnyDictionary.self,
+                                                   from: Data([0xA4, 0x61, 0x62, 0x01, 0x61, 0x7A, 0x02,
+                                                               0x61, 0x6E, 0x03, 0x61, 0x66, 0x04])),
+                   ["b": 1, "z": 2, "n": 3, "f": 4])
+  }
+
 }

--- a/Tests/CBOREncoderTests.swift
+++ b/Tests/CBOREncoderTests.swift
@@ -294,6 +294,14 @@ class CBOREncoderTests: XCTestCase {
     XCTAssertEqual(try encode(BigUInt(1234567)),
                    [0xC2, 0x43, 0x12, 0xD6, 0x87])
   }
+
+  func testEncodeAnyDictionary() throws {
+
+    let dict: AnyValue.AnyDictionary = ["b": 1, "z": 2, "n": 3, "f": 4]
+
+    XCTAssertEqual(try encode(dict),
+                   [0xA4, 0x61, 0x62, 0x01, 0x61, 0x7A, 0x02, 0x61, 0x6E, 0x03, 0x61, 0x66, 0x04])
+  }
 }
 
 extension Array {

--- a/Tests/JSONDecoderTests.swift
+++ b/Tests/JSONDecoderTests.swift
@@ -2298,4 +2298,12 @@ class JSONDecoderTests: XCTestCase {
     }
   }
 
+  func testDecodeAnyDictionaryFromObject() throws {
+
+    let json = #"{"b":1,"z":2,"n":3,"f":4}"#
+
+    let testValue = try JSON.Decoder.default.decode(AnyValue.AnyDictionary.self, from: json)
+    XCTAssertEqual(testValue, ["b": 1, "z": 2, "n": 3, "f": 4])
+  }
+
 }

--- a/Tests/JSONEncoderTests.swift
+++ b/Tests/JSONEncoderTests.swift
@@ -1120,6 +1120,14 @@ class JSONEncoderTests: XCTestCase {
     XCTAssertEqual(testJSON, json)
   }
 
+  func testEncodeAnyDictionary() throws {
+
+    let dict: AnyValue.AnyDictionary = ["b": 1, "z": 2, "n": 3, "f": 4]
+
+    let testJSON = try JSON.Encoder.default.encodeString(dict)
+    XCTAssertEqual(testJSON, #"{"b":1,"z":2,"n":3,"f":4}"#)
+  }
+
   func testEncodeNonStringKeyedDictionary() throws {
 
     struct TestValue: Codable {

--- a/Tests/YAMLDecoderTests.swift
+++ b/Tests/YAMLDecoderTests.swift
@@ -3020,4 +3020,23 @@ class YAMLDecoderTests: XCTestCase {
     }
   }
 
+  func testDecodeAnyDictionary() throws {
+
+    let yaml =
+    """
+    ---
+    b: 1
+    z: 2
+    n: 3
+    f: 4
+    ...
+
+    """
+
+    XCTAssertEqual(
+      try YAML.Decoder.default.decode(AnyValue.AnyDictionary.self, from: yaml),
+      ["b": 1, "z": 2, "n": 3, "f": 4]
+    )
+  }
+
 }

--- a/Tests/YAMLEncoderTests.swift
+++ b/Tests/YAMLEncoderTests.swift
@@ -1262,6 +1262,25 @@ class YAMLEncoderTests: XCTestCase {
     XCTAssertEqual(testYAML, yaml)
   }
 
+  func testEncodeAnyDictionary() throws {
+
+    let dict: AnyValue.AnyDictionary = ["b": 1, "z": 2, "n": 3, "f": 4]
+
+    let yaml =
+    """
+    ---
+    b: 1
+    z: 2
+    n: 3
+    f: 4
+    ...
+
+    """
+
+    let testYAML = try YAML.Encoder.default.encodeString(dict)
+    XCTAssertEqual(testYAML, yaml)
+  }
+
   func testEncodeNonStringKeyedDictionary() throws {
 
     struct TestValue: Codable {


### PR DESCRIPTION
Ensures that when direcly encoding an `AnyValue.AnyDictionary` (not wrapped in an `AnyValue`) the a map or objet is used.

Fixes #53