### PR TITLE
Add TopLevelEncoder & TopLevelDecoder reusing Combine’s if available

### DIFF
--- a/Sources/PotentASN1/ASN1Decoder.swift
+++ b/Sources/PotentASN1/ASN1Decoder.swift
@@ -937,14 +937,8 @@ extension SchemaState {
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension ASN1Decoder: TopLevelDecoder {
-    public typealias Input = Data
-  }
-
-#endif
+extension ASN1Decoder: TopLevelDecoder {
+  public typealias Input = Data
+}
 
 private let nullUUID = uuid_t(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/Sources/PotentASN1/ASN1Encoder.swift
+++ b/Sources/PotentASN1/ASN1Encoder.swift
@@ -658,12 +658,6 @@ extension SchemaState {
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension ASN1Encoder: TopLevelEncoder {
-    public typealias Output = Data
-  }
-
-#endif
+extension ASN1Encoder: TopLevelEncoder {
+  public typealias Output = Data
+}

--- a/Sources/PotentCBOR/CBORDecoder.swift
+++ b/Sources/PotentCBOR/CBORDecoder.swift
@@ -612,12 +612,6 @@ extension Data {
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension CBORDecoder: TopLevelDecoder {
-    public typealias Input = Data
-  }
-
-#endif
+extension CBORDecoder: TopLevelDecoder {
+  public typealias Input = Data
+}

--- a/Sources/PotentCBOR/CBOREncoder.swift
+++ b/Sources/PotentCBOR/CBOREncoder.swift
@@ -282,12 +282,6 @@ public struct CBOREncoderTransform: InternalEncoderTransform, InternalValueSeria
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension CBOREncoder: TopLevelEncoder {
-    public typealias Output = Data
-  }
-
-#endif
+extension CBOREncoder: TopLevelEncoder {
+  public typealias Output = Data
+}

--- a/Sources/PotentCodables/AnyValue/AnyValueDecoder.swift
+++ b/Sources/PotentCodables/AnyValue/AnyValueDecoder.swift
@@ -267,19 +267,13 @@ public struct AnyValueDecoderTransform: InternalDecoderTransform {
 }
 
 
-#if canImport(Combine)
+extension AnyValueDecoder: TopLevelDecoder {
+  public typealias Input = AnyValue
 
-  import Combine
-
-  extension AnyValueDecoder: TopLevelDecoder {
-    public typealias Input = AnyValue
-
-    public func decode<T>(_ type: T.Type, from tree: AnyValue) throws -> T where T: Decodable {
-      return try decodeTree(type, from: tree)
-    }
+  public func decode<T>(_ type: T.Type, from tree: AnyValue) throws -> T where T: Decodable {
+    return try decodeTree(type, from: tree)
   }
-
-#endif
+}
 
 
 

--- a/Sources/PotentCodables/AnyValue/AnyValueEncoder.swift
+++ b/Sources/PotentCodables/AnyValue/AnyValueEncoder.swift
@@ -235,19 +235,13 @@ public struct AnyValueEncoderTransform: InternalEncoderTransform {
 }
 
 
-#if canImport(Combine)
+extension AnyValueEncoder: TopLevelEncoder {
+  public typealias Output = AnyValue
 
-  import Combine
-
-  extension AnyValueEncoder: TopLevelEncoder {
-    public typealias Output = AnyValue
-
-    public func encode<T>(_ value: T) throws -> AnyValue where T: Encodable {
-      return try encodeTree(value)
-    }
+  public func encode<T>(_ value: T) throws -> AnyValue where T: Encodable {
+    return try encodeTree(value)
   }
-
-#endif
+}
 
 
 

--- a/Sources/PotentCodables/TopLevel.swift
+++ b/Sources/PotentCodables/TopLevel.swift
@@ -1,0 +1,41 @@
+//
+//  TopLevel.swift
+//  PotentCodables
+//
+//  Copyright © 2021 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import Foundation
+
+#if canImport(Combine)
+
+@_exported import protocol Combine.TopLevelDecoder
+@_exported import protocol Combine.TopLevelEncoder
+
+#else
+
+public protocol TopLevelDecoder {
+
+  /// The type this decoder accepts.
+  associatedtype Input
+
+  /// Decodes an instance of the indicated type.
+  func decode<T>(_ type: T.Type, from: Self.Input) throws -> T where T: Decodable
+}
+
+/// A type that defines methods for encoding.
+public protocol TopLevelEncoder {
+
+  /// The type this encoder produces.
+  associatedtype Output
+
+  /// Encodes an instance of the indicated type.
+  ///
+  /// - Parameter value: The instance to encode.
+  func encode<T>(_ value: T) throws -> Self.Output where T: Encodable
+}
+
+#endif

--- a/Sources/PotentJSON/JSONDecoder.swift
+++ b/Sources/PotentJSON/JSONDecoder.swift
@@ -567,15 +567,9 @@ extension Data {
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension JSONDecoder: TopLevelDecoder {
-    public typealias Input = Data
-  }
-
-#endif
+extension JSONDecoder: TopLevelDecoder {
+  public typealias Input = Data
+}
 
 
 extension JSONDecoderTransform.Options {

--- a/Sources/PotentJSON/JSONEncoder.swift
+++ b/Sources/PotentJSON/JSONEncoder.swift
@@ -454,12 +454,6 @@ public struct JSONEncoderTransform: InternalEncoderTransform, InternalValueSeria
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension JSONEncoder: TopLevelEncoder {
-    public typealias Output = Data
-  }
-
-#endif
+extension JSONEncoder: TopLevelEncoder {
+  public typealias Output = Data
+}

--- a/Sources/PotentYAML/YAMLDecoder.swift
+++ b/Sources/PotentYAML/YAMLDecoder.swift
@@ -612,12 +612,6 @@ extension Data {
 
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension YAMLDecoder: TopLevelDecoder {
-    public typealias Input = Data
-  }
-
-#endif
+extension YAMLDecoder: TopLevelDecoder {
+  public typealias Input = Data
+}

--- a/Sources/PotentYAML/YAMLEncoder.swift
+++ b/Sources/PotentYAML/YAMLEncoder.swift
@@ -372,12 +372,6 @@ public struct YAMLEncoderTransform: InternalEncoderTransform, InternalValueSeria
 }
 
 
-#if canImport(Combine)
-
-  import Combine
-
-  extension YAMLEncoder: TopLevelEncoder {
-    public typealias Output = Data
-  }
-
-#endif
+extension YAMLEncoder: TopLevelEncoder {
+  public typealias Output = Data
+}


### PR DESCRIPTION
Adds definitions for `TopeLevelEncoder` and `TopLevelDecoder`. If `Combine` is available, those protocols are simply exported from the PotentCodablees module. When `Combine` is not available it defines the protocols as being equivalent to `Combine`’s versions.