### PR TITLE
Require transformer `Source` types to be `Encodable` or `Decodable`

### DIFF
--- a/Sources/PotentCodables/ValueTransformer.swift
+++ b/Sources/PotentCodables/ValueTransformer.swift
@@ -18,7 +18,7 @@ public typealias ValueCodingTransformer = ValueEncodingTransformer & ValueDecodi
 
 public protocol ValueDecodingTransformer {
 
-  associatedtype Source
+  associatedtype Source: Decodable
   associatedtype Target
 
   func decode(_ value: Source) throws -> Target
@@ -420,7 +420,7 @@ public extension SingleValueDecodingContainer {
 
 public protocol ValueEncodingTransformer {
 
-  associatedtype Source
+  associatedtype Source: Codable
   associatedtype Target
 
   func encode(_ value: Target) throws -> Source

--- a/Tests/ValueTransformerTests.swift
+++ b/Tests/ValueTransformerTests.swift
@@ -1522,7 +1522,7 @@ struct IntToBool: ValueCodingTransformer {
   }
 }
 
-struct BoolToInt<Value: FixedWidthInteger>: ValueCodingTransformer {
+struct BoolToInt<Value: FixedWidthInteger & Codable>: ValueCodingTransformer {
 
   func encode(_ value: Bool) throws -> Value {
     return value ? 1 : 0
@@ -1533,7 +1533,7 @@ struct BoolToInt<Value: FixedWidthInteger>: ValueCodingTransformer {
   }
 }
 
-struct BoolToFloat<Value: BinaryFloatingPoint>: ValueCodingTransformer {
+struct BoolToFloat<Value: BinaryFloatingPoint & Codable>: ValueCodingTransformer {
 
   func encode(_ value: Bool) throws -> Value {
     return value ? 1.0 : 0.0


### PR DESCRIPTION
This adds a constraint that _should_ already exist and indeed is required by implmenenting code as is.

Should not effect any current implementations.