### PR TITLE
Add `decodeContents(using:)` and use generic sequence in `encode(:,using:)` for `UnkeyedDecodingContainer`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,8 +30,8 @@ trailing_comma:
   mandatory_comma: true
 
 file_length:
-  warning: 800
-  error: 1000
+  warning: 1500
+  error: 3000
   ignore_comment_only_lines: true
 
 line_length:

--- a/Sources/PotentCodables/ValueTransformer.swift
+++ b/Sources/PotentCodables/ValueTransformer.swift
@@ -1364,108 +1364,108 @@ public extension UnkeyedEncodingContainer {
     }
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Bool {
+  ) throws where Transformer.Source == Bool, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == String {
+  ) throws where Transformer.Source == String, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Int {
+  ) throws where Transformer.Source == Int, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Int8 {
+  ) throws where Transformer.Source == Int8, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Int16 {
+  ) throws where Transformer.Source == Int16, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Int32 {
+  ) throws where Transformer.Source == Int32, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Int64 {
+  ) throws where Transformer.Source == Int64, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == UInt {
+  ) throws where Transformer.Source == UInt, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == UInt8 {
+  ) throws where Transformer.Source == UInt8, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == UInt16 {
+  ) throws where Transformer.Source == UInt16, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == UInt32 {
+  ) throws where Transformer.Source == UInt32, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == UInt64 {
+  ) throws where Transformer.Source == UInt64, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Float {
+  ) throws where Transformer.Source == Float, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source == Double {
+  ) throws where Transformer.Source == Double, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 
-  mutating func encode<Transformer: ValueEncodingTransformer>(
-    contentsOf values: [Transformer.Target],
+  mutating func encode<S: Sequence, Transformer: ValueEncodingTransformer>(
+    contentsOf values: S,
     using transformer: Transformer
-  ) throws where Transformer.Source: Encodable {
+  ) throws where Transformer.Source: Encodable, S.Element == Transformer.Target {
     try encode(contentsOf: values.map { try transformer.encode($0) })
   }
 

--- a/Sources/PotentCodables/ValueTransformer.swift
+++ b/Sources/PotentCodables/ValueTransformer.swift
@@ -343,6 +343,450 @@ public extension UnkeyedDecodingContainer {
     try decodeIfPresent(Transformer.Source.self).flatMap { try transformer.decode($0) }
   }
 
+  mutating func decodeContents(_ type: Bool.Type) throws -> [Bool] {
+    var elements: [Bool] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: String.Type) throws -> [String] {
+    var elements: [String] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int8.Type) throws -> [Int8] {
+    var elements: [Int8] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int16.Type) throws -> [Int16] {
+    var elements: [Int16] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int32.Type) throws -> [Int32] {
+    var elements: [Int32] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int64.Type) throws -> [Int64] {
+    var elements: [Int64] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+
+  mutating func decodeContents(_ type: UInt8.Type) throws -> [UInt8] {
+    var elements: [UInt8] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt16.Type) throws -> [UInt16] {
+    var elements: [UInt16] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt32.Type) throws -> [UInt32] {
+    var elements: [UInt32] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt64.Type) throws -> [UInt64] {
+    var elements: [UInt64] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Float.Type) throws -> [Float] {
+    var elements: [Float] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Double.Type) throws -> [Double] {
+    var elements: [Double] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Value: Decodable>(_ type: Value.Type) throws -> [Value] {
+    var elements: [Value] = []
+    while !self.isAtEnd {
+      elements.append(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Bool.Type) throws -> Set<Bool> {
+    var elements: Set<Bool> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: String.Type) throws -> Set<String> {
+    var elements: Set<String> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int8.Type) throws -> Set<Int8> {
+    var elements: Set<Int8> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int16.Type) throws -> Set<Int16> {
+    var elements: Set<Int16> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int32.Type) throws -> Set<Int32> {
+    var elements: Set<Int32> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Int64.Type) throws -> Set<Int64> {
+    var elements: Set<Int64> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+
+  mutating func decodeContents(_ type: UInt8.Type) throws -> Set<UInt8> {
+    var elements: Set<UInt8> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt16.Type) throws -> Set<UInt16> {
+    var elements: Set<UInt16> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt32.Type) throws -> Set<UInt32> {
+    var elements: Set<UInt32> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: UInt64.Type) throws -> Set<UInt64> {
+    var elements: Set<UInt64> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Float.Type) throws -> Set<Float> {
+    var elements: Set<Float> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents(_ type: Double.Type) throws -> Set<Double> {
+    var elements: Set<Double> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Value: Decodable & Hashable>(_ type: Value.Type) throws -> Set<Value> {
+    var elements: Set<Value> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(type))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Bool {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == String {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Int8 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Int16 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Int32 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Int64 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == UInt8 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == UInt16 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == UInt32 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == UInt64 {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Float {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source == Double {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> [Transformer.Target] where Transformer.Source: Decodable {
+    var elements: [Transformer.Target] = []
+    while !self.isAtEnd {
+      elements.append(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Bool {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == String {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Int8 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Int16 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Int32 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Int64 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == UInt8 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == UInt16 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == UInt32 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == UInt64 {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Float {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source == Double {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
+  mutating func decodeContents<Transformer: ValueDecodingTransformer>(using transformer: Transformer) throws
+  -> Set<Transformer.Target> where Transformer.Source: Decodable {
+    var elements: Set<Transformer.Target> = []
+    while !self.isAtEnd {
+      elements.insert(try decode(using: transformer))
+    }
+    return elements
+  }
+
 }
 
 public extension SingleValueDecodingContainer {
@@ -1142,7 +1586,7 @@ public extension SingleValueEncodingContainer {
 public extension TopLevelDecoder {
 
   func decode<Transformer: ValueDecodingTransformer>(from input: Input, using transformer: Transformer) throws
-    -> Transformer.Target {
+    -> Transformer.Target where Transformer.Source: Decodable {
     return try transformer.decode(decode(Transformer.Source.self, from: input))
   }
 
@@ -1151,7 +1595,7 @@ public extension TopLevelDecoder {
 public extension TopLevelEncoder {
 
   func encode<Transformer: ValueEncodingTransformer>(_ value: Transformer.Target, using transformer: Transformer) throws
-    -> Output {
+    -> Output where Transformer.Source: Encodable {
     return try encode(transformer.encode(value))
   }
 

--- a/Tests/UnkeyedCodingContainerTests.swift
+++ b/Tests/UnkeyedCodingContainerTests.swift
@@ -1,0 +1,624 @@
+//
+//  UnkeyedCodingContainerTests.swift
+//  PotentCodables
+//
+//  Copyright © 2021 Outfox, inc.
+//
+//
+//  Distributed under the MIT License, See LICENSE for details.
+//
+
+import PotentCodables
+import PotentJSON
+import XCTest
+
+
+public class UnkeyedCodingContainerTests: XCTestCase {
+
+  func testDecodeContentsBoolArray() throws {
+
+    struct Bools: Codable, Equatable {
+      var values: [Bool]
+      init(values: [Bool]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Bool.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Bools(values: [true, false])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Bools.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsStringArray() throws {
+
+    struct Strings: Codable, Equatable {
+      var values: [String]
+      init(values: [String]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(String.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Strings(values: ["a", "b"])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Strings.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt8Array() throws {
+
+    struct Int8s: Codable, Equatable {
+      var values: [Int8]
+      init(values: [Int8]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int8.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int8s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int8s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt16Array() throws {
+
+    struct Int16s: Codable, Equatable {
+      var values: [Int16]
+      init(values: [Int16]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int16.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int16s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int16s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt32Array() throws {
+
+    struct Int32s: Codable, Equatable {
+      var values: [Int32]
+      init(values: [Int32]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int32.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int32s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int32s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt64Array() throws {
+
+    struct Int64s: Codable, Equatable {
+      var values: [Int64]
+      init(values: [Int64]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int64.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int64s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int64s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt8Array() throws {
+
+    struct UInt8s: Codable, Equatable {
+      var values: [UInt8]
+      init(values: [UInt8]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt8.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt8s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt8s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt16Array() throws {
+
+    struct UInt16s: Codable, Equatable {
+      var values: [UInt16]
+      init(values: [UInt16]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt16.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt16s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt16s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt32Array() throws {
+
+    struct UInt32s: Codable, Equatable {
+      var values: [UInt32]
+      init(values: [UInt32]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt32.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt32s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt32s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt64Array() throws {
+
+    struct UInt64s: Codable, Equatable {
+      var values: [UInt64]
+      init(values: [UInt64]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt64.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt64s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt64s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsFloatArray() throws {
+
+    struct Floats: Codable, Equatable {
+      var values: [Float]
+      init(values: [Float]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Float.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Floats(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Floats.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsDoubleArray() throws {
+
+    struct Doubles: Codable, Equatable {
+      var values: [Double]
+      init(values: [Double]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Double.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Doubles(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Doubles.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsDecodableArray() throws {
+
+    struct Test: Codable, Equatable {
+      var int: Int
+    }
+
+    struct Tests: Codable, Equatable {
+      var values: [Test]
+      init(values: [Test]) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Test.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Tests(values: [Test(int: 1), Test(int: 2), Test(int: 3)])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Tests.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsBoolSet() throws {
+
+    struct Bools: Codable, Equatable {
+      var values: Set<Bool>
+      init(values: Set<Bool>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Bool.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Bools(values: [true, false])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Bools.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsStringSet() throws {
+
+    struct Strings: Codable, Equatable {
+      var values: Set<String>
+      init(values: Set<String>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(String.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Strings(values: ["a", "b"])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Strings.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt8Set() throws {
+
+    struct Int8s: Codable, Equatable {
+      var values: Set<Int8>
+      init(values: Set<Int8>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int8.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int8s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int8s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt16Set() throws {
+
+    struct Int16s: Codable, Equatable {
+      var values: Set<Int16>
+      init(values: Set<Int16>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int16.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int16s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int16s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt32Set() throws {
+
+    struct Int32s: Codable, Equatable {
+      var values: Set<Int32>
+      init(values: Set<Int32>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int32.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int32s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int32s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsInt64Set() throws {
+
+    struct Int64s: Codable, Equatable {
+      var values: Set<Int64>
+      init(values: Set<Int64>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Int64.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Int64s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Int64s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt8Set() throws {
+
+    struct UInt8s: Codable, Equatable {
+      var values: Set<UInt8>
+      init(values: Set<UInt8>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt8.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt8s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt8s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt16Set() throws {
+
+    struct UInt16s: Codable, Equatable {
+      var values: Set<UInt16>
+      init(values: Set<UInt16>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt16.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt16s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt16s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt32Set() throws {
+
+    struct UInt32s: Codable, Equatable {
+      var values: Set<UInt32>
+      init(values: Set<UInt32>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt32.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt32s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt32s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsUInt64Set() throws {
+
+    struct UInt64s: Codable, Equatable {
+      var values: Set<UInt64>
+      init(values: Set<UInt64>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(UInt64.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = UInt64s(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(UInt64s.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsFloatSet() throws {
+
+    struct Floats: Codable, Equatable {
+      var values: Set<Float>
+      init(values: Set<Float>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Float.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Floats(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Floats.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsDoubleSet() throws {
+
+    struct Doubles: Codable, Equatable {
+      var values: Set<Double>
+      init(values: Set<Double>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Double.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Doubles(values: [1, 2, 3])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Doubles.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testDecodeContentsDecodableSet() throws {
+
+    struct Test: Codable, Equatable, Hashable {
+      var int: Int
+    }
+
+    struct Tests: Codable, Equatable {
+      var values: Set<Test>
+      init(values: Set<Test>) {
+        self.values = values
+      }
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.values = try container.decodeContents(Test.self)
+      }
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(contentsOf: values)
+      }
+    }
+
+    let encoded = Tests(values: [Test(int: 1), Test(int: 2), Test(int: 3)])
+    let data = try JSONEncoder.default.encode(encoded)
+    let decoded = try JSONDecoder.default.decode(Tests.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+}

--- a/Tests/ValueTransformerTests.swift
+++ b/Tests/ValueTransformerTests.swift
@@ -132,10 +132,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: IntToBool()))
-        }
+        value = try container.decodeContents(using: IntToBool())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -159,10 +156,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<Int>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<Int>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -186,10 +180,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<Int8>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<Int8>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -213,10 +204,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<Int16>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<Int16>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -240,10 +228,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<Int32>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<Int32>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -267,10 +252,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<Int64>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<Int64>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -294,10 +276,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<UInt>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<UInt>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -321,10 +300,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<UInt8>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<UInt8>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -348,10 +324,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<UInt16>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<UInt16>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -375,10 +348,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<UInt32>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<UInt32>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -402,10 +372,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToInt<UInt64>()))
-        }
+        value = try container.decodeContents(using: BoolToInt<UInt64>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -429,10 +396,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToFloat<Float>()))
-        }
+        value = try container.decodeContents(using: BoolToFloat<Float>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -456,10 +420,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToFloat<Double>()))
-        }
+        value = try container.decodeContents(using: BoolToFloat<Double>())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -483,10 +444,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToString()))
-        }
+        value = try container.decodeContents(using: BoolToString())
       }
 
       func encode(to encoder: Encoder) throws {
@@ -510,10 +468,7 @@ class ValueTransformerTests: XCTestCase {
 
       init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        value = []
-        while !container.isAtEnd {
-          value.append(try container.decode(using: BoolToBoolValue()))
-        }
+        value = try container.decodeContents(using: BoolToBoolValue())
       }
 
       func encode(to encoder: Encoder) throws {

--- a/Tests/ValueTransformerTests.swift
+++ b/Tests/ValueTransformerTests.swift
@@ -121,7 +121,7 @@ class ValueTransformerTests: XCTestCase {
     )
   }
 
-  func testUnkeyedCollectionBoolStoredInt() throws {
+  func testArrayBoolStoredInt() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Int]
@@ -145,7 +145,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([true, false])), TestValue(value: [1, 0]))
   }
 
-  func testUnkeyedCollectionIntStoredBool() throws {
+  func testArrayIntStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -169,7 +169,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionInt8StoredBool() throws {
+  func testArrayInt8StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -193,7 +193,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionInt16StoredBool() throws {
+  func testArrayInt16StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -217,7 +217,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionInt32StoredBool() throws {
+  func testArrayInt32StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -241,7 +241,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionInt64StoredBool() throws {
+  func testArrayInt64StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -265,7 +265,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionUIntStoredBool() throws {
+  func testArrayUIntStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -289,7 +289,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionUInt8StoredBool() throws {
+  func testArrayUInt8StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -313,7 +313,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionUInt16StoredBool() throws {
+  func testArrayUInt16StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -337,7 +337,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionUInt32StoredBool() throws {
+  func testArrayUInt32StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -361,7 +361,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionUInt64StoredBool() throws {
+  func testArrayUInt64StoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -385,7 +385,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1, 0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionFloatStoredBool() throws {
+  func testArrayFloatStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -409,7 +409,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1.0, 0.0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionDoubleStoredBool() throws {
+  func testArrayDoubleStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -433,7 +433,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([1.0, 0.0])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionStringStoredBool() throws {
+  func testArrayStringStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -457,7 +457,7 @@ class ValueTransformerTests: XCTestCase {
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array(["true", "false"])), TestValue(value: [true, false]))
   }
 
-  func testUnkeyedCollectionBoolValueStoredBool() throws {
+  func testArrayBoolValueStoredBool() throws {
 
     struct TestValue: Codable, Equatable {
       var value: [Bool]
@@ -479,6 +479,396 @@ class ValueTransformerTests: XCTestCase {
 
     XCTAssertEqual(try JSON.Encoder.default.encodeTree(TestValue(value: [true, false])), JSON.array([true, false]))
     XCTAssertEqual(try JSON.Decoder.default.decodeTree(TestValue.self, from: JSON.array([true, false])), TestValue(value: [true, false]))
+  }
+
+  func testSetBoolStoredInt() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Int>
+
+      init(value: Set<Int>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: IntToBool())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: IntToBool())
+      }
+    }
+
+    let encoded = TestValue(value: [1, 0])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetIntStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<Int>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<Int>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetInt8StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<Int8>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<Int8>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetInt16StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<Int16>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<Int16>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetInt32StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<Int32>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<Int32>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetInt64StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<Int64>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<Int64>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetUIntStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<UInt>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<UInt>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetUInt8StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<UInt8>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<UInt8>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetUInt16StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<UInt16>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<UInt16>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetUInt32StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<UInt32>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<UInt32>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetUInt64StoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToInt<UInt64>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToInt<UInt64>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetFloatStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToFloat<Float>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToFloat<Float>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetDoubleStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToFloat<Double>())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToFloat<Double>())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetStringStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToString())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToString())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
+  }
+
+  func testSetBoolValueStoredBool() throws {
+
+    struct TestValue: Codable, Equatable {
+      var value: Set<Bool>
+
+      init(value: Set<Bool>) {
+        self.value = value
+      }
+
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        value = try container.decodeContents(using: BoolToBoolValue())
+      }
+
+      func encode(to encoder: Encoder) throws {
+        var contaier = encoder.unkeyedContainer()
+        try contaier.encode(contentsOf: value, using: BoolToBoolValue())
+      }
+    }
+
+    let encoded = TestValue(value: [true, false])
+    let data = try JSON.Encoder.default.encode(encoded)
+    let decoded = try JSON.Decoder.default.decode(TestValue.self, from: data)
+    XCTAssertEqual(encoded, decoded)
   }
 
   func testSingleBoolStoredInt() throws {


### PR DESCRIPTION
These match the existing provided `encode(contentsOf:)` on `UnkeyedEncodingContainer`.