### PR TITLE
Better error messages for JSON/YAML/CBOR decoders

### DIFF
--- a/Sources/PotentCBOR/CBORDecoder.swift
+++ b/Sources/PotentCBOR/CBORDecoder.swift
@@ -126,7 +126,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .boolean(let value): return value
     case .null: return nil
     case let cbor:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: cbor)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: cbor.unwrapped)
     }
   }
 
@@ -171,7 +171,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return try unbox(untagged, type: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -183,7 +183,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
         let exp = try? unbox(items[0], type: Int.self, decoder: decoder),
         let man = try? unbox(items[1], type: BigInt.self, decoder: decoder)
       else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
       }
       guard let sig = Decimal(string: man.magnitude.description) else {
         throw overflow(type, value: value, at: decoder.codingPath)
@@ -218,7 +218,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return try unbox(untagged, type: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -229,7 +229,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
         let exp = try? unbox(items[0], type: Int.self, decoder: decoder),
         let man = try? unbox(items[1], type: BigInt.self, decoder: decoder)
       else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
       }
       // CHECK: Decimal(exactly:) is a fatal error for all inputs?
       guard let sig = Decimal(string: man.magnitude.description) else {
@@ -267,7 +267,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return try unbox(untagged, type: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -332,7 +332,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .utf8String(let string), .tagged(_, .utf8String(let string)): return string
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -348,7 +348,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
 
     func decode(from data: Data) throws -> UUID {
       guard data.count == MemoryLayout<uuid_t>.size else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
       }
       var uuid = uuid_t(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
       withUnsafeMutableBytes(of: &uuid) { ptr in
@@ -365,7 +365,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .tagged(_, let tagged): return try unbox(tagged, as: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -379,7 +379,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .tagged(_, let tagged): return try unbox(tagged, as: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -421,7 +421,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return try unbox(tagged, as: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -440,7 +440,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return data
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -456,7 +456,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .tagged(_, let tagged): return try unbox(tagged, as: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -469,7 +469,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .tagged(_, let untagged): return try unbox(untagged, as: type, decoder: decoder)
     case .null: return nil
     default:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
   }
 
@@ -515,17 +515,17 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return try dictionary(from: value)
     case .tagged(.positiveBignum, _), .tagged(.negativeBignum, _):
       guard let int = try unbox(value, as: BigInt.self, decoder: decoder) else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: BigInt.self, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: BigInt.self, reality: value.unwrapped)
       }
       return .integer(int)
     case .tagged(.decimalFraction, _):
       guard let decimal = try unbox(value, as: Decimal.self, decoder: decoder) else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: Decimal.self, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: Decimal.self, reality: value.unwrapped)
       }
       return .decimal(decimal)
     case .tagged(.iso8601DateTime, _), .tagged(.epochDateTime, _):
       guard let date = try unbox(value, as: Date.self, decoder: decoder) else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: Date.self, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: Date.self, reality: value.unwrapped)
       }
       return .date(date)
     case .tagged(.uuid, _):
@@ -545,7 +545,7 @@ public struct CBORDecoderTransform: InternalDecoderTransform, InternalValueDeser
     decoder: IVD
   ) throws -> AnyValue.AnyDictionary {
     guard case .map(let map) = value else {
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
     return AnyValue.AnyDictionary(uniqueKeysWithValues: try map.map { key, value in
       let key = try unbox(key, as: AnyValue.self, decoder: decoder)

--- a/Sources/PotentCodables/Errors.swift
+++ b/Sources/PotentCodables/Errors.swift
@@ -18,7 +18,7 @@ public extension DecodingError {
   /// - parameter expectation: The type expected to be encountered.
   /// - parameter reality: The value that was encountered instead of the expected type.
   /// - returns: A `DecodingError` with the appropriate path and debug description.
-  static func typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Any) -> DecodingError {
+  static func typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Any?) -> DecodingError {
     let description = "Expected to decode \(expectation) but found \(typeDescription(of: reality)) instead."
     return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
   }
@@ -28,7 +28,7 @@ public extension DecodingError {
   /// - parameter value: The value whose type to describe.
   /// - returns: A string describing `value`.
   /// - precondition: `value` is one of the types below.
-  static func typeDescription(of value: Any) -> String {
+  static func typeDescription(of value: Any?) -> String {
     if value is NSNull {
       return "a null value"
     }
@@ -36,7 +36,7 @@ public extension DecodingError {
       return "a number"
     }
     else if value is String {
-      return "a string/data"
+      return "a string"
     }
     else if value is [Any] {
       return "an array"
@@ -45,7 +45,11 @@ public extension DecodingError {
       return "a dictionary"
     }
     else {
-      return "\(type(of: value))"
+      if let nonOptionalValue = value {
+        return String(describing: type(of: nonOptionalValue))
+      } else {
+        return "nil"
+      }
     }
   }
 }

--- a/Sources/PotentJSON/JSONDecoder.swift
+++ b/Sources/PotentJSON/JSONDecoder.swift
@@ -164,7 +164,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .bool(let value): return value
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -194,7 +194,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -203,7 +203,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -212,7 +212,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -221,7 +221,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -230,7 +230,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -239,7 +239,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -248,7 +248,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -257,7 +257,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -266,7 +266,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -275,7 +275,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .number(let number): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -288,7 +288,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return int
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -301,7 +301,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return int
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -316,7 +316,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(_ value: JSON, as type: Float.Type, decoder: IVD) throws -> Float? {
@@ -330,7 +330,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(_ value: JSON, as type: Double.Type, decoder: IVD) throws -> Double? {
@@ -344,7 +344,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(_ value: JSON, as type: Decimal.Type, decoder: IVD) throws -> Decimal? {
@@ -358,7 +358,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(_ value: JSON, as type: String.Type, decoder: IVD) throws -> String? {
@@ -367,7 +367,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return string
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -380,7 +380,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return uuid
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -393,7 +393,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return url
     case .null: return nil
     case let json:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: json.unwrapped)
     }
   }
 
@@ -452,7 +452,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
 
     func decodeBase64(from value: JSON) throws -> Data {
       guard case .string(let string) = value else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
       }
 
       guard let data = Data(base64EncodedUnpadded: string) else {
@@ -525,7 +525,7 @@ public struct JSONDecoderTransform: InternalDecoderTransform, InternalValueDeser
     decoder: IVD
   ) throws -> AnyValue.AnyDictionary {
     guard case .object(let object) = value else {
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
     return AnyValue.AnyDictionary(uniqueKeysWithValues: try object.map { key, value in
       (.string(key), try unbox(value, as: AnyValue.self, decoder: decoder))

--- a/Sources/PotentYAML/YAMLDecoder.swift
+++ b/Sources/PotentYAML/YAMLDecoder.swift
@@ -159,7 +159,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .bool(let value, _): return value
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -202,7 +202,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -211,7 +211,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -220,7 +220,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -229,7 +229,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -238,7 +238,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -247,7 +247,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -256,7 +256,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -265,7 +265,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -274,7 +274,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -283,7 +283,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return try coerce(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -292,7 +292,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .integer(let number, _): return BigInt(number.value)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -305,7 +305,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return BigUInt(number.value)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -317,7 +317,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(_ value: YAML, as type: Float.Type, decoder: IVD) throws -> Float? {
@@ -326,7 +326,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .float(let number, _): return try decode(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -336,7 +336,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .float(let number, _): return try decode(number, at: decoder.codingPath)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -376,7 +376,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     case .float(let number, _): return try decodeFloat(number)
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -386,7 +386,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return string
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -399,7 +399,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return uuid
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -412,7 +412,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
       return url
     case .null: return nil
     case let yaml:
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: yaml.unwrapped)
     }
   }
 
@@ -471,7 +471,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
 
     func decodeBase64(from value: YAML) throws -> Data {
       guard case .string(let string, _, _, _) = value else {
-        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+        throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
       }
 
       guard let data = Data(base64EncodedUnpadded: string) else {
@@ -539,7 +539,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     default:
       break
     }
-    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+    throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
   }
 
   public static func unbox(
@@ -548,7 +548,7 @@ public struct YAMLDecoderTransform: InternalDecoderTransform, InternalValueDeser
     decoder: IVD
   ) throws -> AnyValue.AnyDictionary {
     guard case .mapping(let mapping, _, _, _) = value else {
-      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value)
+      throw DecodingError.typeMismatch(at: decoder.codingPath, expectation: type, reality: value.unwrapped)
     }
     return AnyValue.AnyDictionary(uniqueKeysWithValues: try mapping.map { entry in
       (try unbox(entry.key, as: AnyValue.self, decoder: decoder),


### PR DESCRIPTION
* Fixes the message building to get actual type instead of Optional<Any>
* Unwraps tree values being unboxed to report the actual Swift type