### PR TITLE
CBOR: Use Data.startIndex to ensure correct offset for slices

### DIFF
--- a/Sources/PotentCBOR/CBORStream.swift
+++ b/Sources/PotentCBOR/CBORStream.swift
@@ -62,15 +62,16 @@ public class CBORDataStream: CBORInputStream, CBOROutputStream {
 
   public init(data: Data = Data(), offset: Int = 0) {
     self.data = data
-    self.offset = offset
+    self.offset = offset + data.startIndex
   }
 
   public func reset() {
     data.removeAll()
+    offset = data.startIndex
   }
 
   func checkAvailable(count: Int) throws {
-    if (offset + count) > data.count {
+    if (offset + count) > data.endIndex {
       throw CBORSerialization.Error.unexpectedEndOfStream
     }
   }

--- a/Tests/CBORDecoderTests.swift
+++ b/Tests/CBORDecoderTests.swift
@@ -16,6 +16,12 @@ import XCTest
 
 class CBORDecoderTests: XCTestCase {
 
+  func testDecodeFromSlice() {
+    let data = Data([0x1, 0x2, 0x3, 0x64, 0x49, 0x45, 0x54, 0x46, 0x3, 0x2, 0x1])
+    let slice = data[3..<data.count-3]
+    XCTAssertEqual(try CBORDecoder.default.decode(String.self, from: slice), "IETF")
+  }
+
   func testDecodeEmpty() {
     struct Empty: Equatable, Codable {}
     XCTAssertEqual(try CBORDecoder.default.decode(Empty.self, from: Data([0xA0])), Empty())


### PR DESCRIPTION
Fixes #84