### PR TITLE
Swift 6 Compatibility/Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-          "version": "5.3.0"
+          "revision": "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+          "version": "5.7.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
+          "revision": "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+          "version": "1.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -112,8 +112,14 @@ let package = Package(
       dependencies: ["PotentCodables", "PotentJSON", "PotentCBOR", "PotentASN1", "PotentYAML"],
       path: "./Tests"
     )
-  ],
+  ]
 )
+
+#if swift(>=6)
+package.swiftLanguageModes = [.v5, .v6]
+#elseif swift(<6)
+package.swiftLanguageVersions = [.v5]
+#endif
 
 #if swift(>=5.6)
 

--- a/Package.swift
+++ b/Package.swift
@@ -43,9 +43,9 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
+    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.7.0"),
     .package(url: "https://github.com/SusanDoggie/Float16.git", from: "1.1.1"),
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.2.1"),
     .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.1")
   ],
   targets: [
@@ -112,7 +112,7 @@ let package = Package(
       dependencies: ["PotentCodables", "PotentJSON", "PotentCBOR", "PotentASN1", "PotentYAML"],
       path: "./Tests"
     )
-  ]
+  ],
 )
 
 #if swift(>=5.6)

--- a/Sources/PotentASN1/ASN1.swift
+++ b/Sources/PotentASN1/ASN1.swift
@@ -21,7 +21,7 @@ public indirect enum ASN1 {
   public typealias AnyTag = UInt8
 
   /// ASN.1 Tag
-  public enum Tag: UInt8, CaseIterable, Codable {
+  public enum Tag: UInt8, CaseIterable {
 
     /// Class of ASN.1 Tag
     public enum Class: UInt8 {
@@ -370,6 +370,7 @@ public func == (lhs: ASN1.AnyTag, rhs: ASN1.Tag) -> Bool {
 
 
 extension ASN1: Hashable {}
+extension ASN1: Sendable {}
 extension ASN1: Value {
 
   /// Check if this value is an ASN.1 ``null``.
@@ -378,6 +379,20 @@ extension ASN1: Value {
   }
 
 }
+
+
+extension ASN1.Tag.Class: Equatable {}
+
+extension ASN1.Tag.Class: Hashable {}
+
+extension ASN1.Tag.Class: Sendable {}
+
+
+extension ASN1.Tag: Equatable {}
+
+extension ASN1.Tag: Hashable {}
+
+extension ASN1.Tag: Sendable {}
 
 extension ASN1.Tag: CustomStringConvertible {
 

--- a/Sources/PotentCBOR/CBOR.swift
+++ b/Sources/PotentCBOR/CBOR.swift
@@ -38,7 +38,7 @@ public indirect enum CBOR {
 
   /// A CBOR `tag` for tagged values supported by the specification.
   ///
-  public struct Tag: RawRepresentable, Equatable, Hashable {
+  public struct Tag: RawRepresentable {
     public let rawValue: UInt64
 
     public init(rawValue: UInt64) {
@@ -256,8 +256,13 @@ public extension CBOR.Tag {
 
 // MARK: Conformances
 
+extension CBOR.Tag: Equatable {}
+extension CBOR.Tag: Hashable {}
+extension CBOR.Tag: Sendable {}
+
 extension CBOR: Equatable {}
 extension CBOR: Hashable {}
+extension CBOR: Sendable {}
 extension CBOR: Value {
 
   public var isNull: Bool {
@@ -343,7 +348,7 @@ extension CBOR: ExpressibleByNilLiteral, ExpressibleByIntegerLiteral, Expressibl
 }
 
 
-// Make encoders/decoders available in AnyValue namespace
+// Make encoders/decoders available in CBOR namespace
 
 public extension CBOR {
 

--- a/Sources/PotentCodables/AnyValue/AnyValue.swift
+++ b/Sources/PotentCodables/AnyValue/AnyValue.swift
@@ -30,7 +30,7 @@ import OrderedCollections
 ///     anyArray[0]
 ///
 @dynamicMemberLookup
-public enum AnyValue {
+public enum AnyValue: Sendable {
 
   public enum Error: Swift.Error {
     case unsupportedType

--- a/Sources/PotentCodables/ZonedDate.swift
+++ b/Sources/PotentCodables/ZonedDate.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /// Date and explicit specific time zone.
 ///
-public struct ZonedDate: Equatable, Hashable, Codable {
+public struct ZonedDate: Equatable, Hashable, Codable, Sendable {
 
   /// Date in UTC time zone.
   public var date: Date

--- a/Sources/PotentJSON/JSON.swift
+++ b/Sources/PotentJSON/JSON.swift
@@ -39,7 +39,7 @@ public enum JSON {
     case invalidNumber
   }
 
-  public struct Number: Equatable, Hashable, Codable {
+  public struct Number {
 
     public var value: String
     public var isInteger: Bool
@@ -213,8 +213,14 @@ public enum JSON {
 
 // MARK: Conformances
 
+extension JSON.Number: Equatable {}
+extension JSON.Number: Hashable {}
+extension JSON.Number: Codable {}
+extension JSON.Number: Sendable {}
+
 extension JSON: Equatable {}
 extension JSON: Hashable {}
+extension JSON: Sendable {}
 extension JSON: Value {
 
   public var isNull: Bool {
@@ -321,7 +327,7 @@ extension JSON.Number: ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, E
 }
 
 
-// Make encoders/decoders available in AnyValue namespace
+// Make encoders/decoders available in JSON namespace
 
 public extension JSON {
 

--- a/Sources/PotentYAML/YAML.swift
+++ b/Sources/PotentYAML/YAML.swift
@@ -35,7 +35,7 @@ import PotentCodables
 @dynamicMemberLookup
 public enum YAML {
 
-  public struct Tag: RawRepresentable, Equatable, Hashable, CustomStringConvertible {
+  public struct Tag: RawRepresentable {
 
     public let rawValue: String
 
@@ -60,13 +60,11 @@ public enum YAML {
 
     public static let seq = Tag("tag:yaml.org,2002:seq")
     public static let map = Tag("tag:yaml.org,2002:map")
-
-    public var description: String { "!\(rawValue)" }
   }
 
   public typealias Anchor = String
 
-  public struct Number: Equatable, Hashable, Codable {
+  public struct Number {
 
     public var value: String
     public var isInteger: Bool
@@ -164,15 +162,11 @@ public enum YAML {
       }
       return double
     }
-
-    public static func == (lhs: Number, rhs: Number) -> Bool {
-      return lhs.value == rhs.value && lhs.isInteger == rhs.isInteger && lhs.isNegative == rhs.isNegative
-    }
   }
 
   public typealias Sequence = [YAML]
 
-  public struct MappingEntry: Equatable, Hashable {
+  public struct MappingEntry {
     public var key: YAML
     public var value: YAML
 
@@ -258,6 +252,8 @@ public enum YAML {
     return .mapping(mapping.map { .init(key: $0.key, value: $0.value) }, style: style, tag: tag, anchor: anchor)
   }
 
+  // MARK: Accessor and Unwrapping
+
   public var stringValue: String? {
     guard case .string(let value, _, _, _) = self else { return nil }
     return value
@@ -306,10 +302,79 @@ public enum YAML {
     return value
   }
 
+  public var unwrapped: Any? {
+    switch self {
+    case .null, .alias: return nil
+    case .bool(let value, _): return value
+    case .string(let value, _, _, _): return value
+    case .integer(let value, _): return value.numberValue
+    case .float(let value, _): return value.numberValue
+    case .sequence(let value, _, _, _): return Swift.Array(value.map(\.unwrapped))
+    case .mapping(let value, _, _, _): return Dictionary(uniqueKeysWithValues: value.map { entry in
+      (entry.key.stringValue!, entry.value.unwrapped)
+    })
+    }
+  }
+
 }
 
 
 // MARK: Conformances
+
+extension YAML.Tag: Equatable {}
+
+extension YAML.Tag: Hashable {}
+
+extension YAML.Tag: Sendable {}
+
+extension YAML.Tag: CustomStringConvertible {
+
+  public var description: String { "!\(rawValue)" }
+
+}
+
+
+extension YAML.Number: Equatable {
+
+  public static func == (lhs: YAML.Number, rhs: YAML.Number) -> Bool {
+    return lhs.value == rhs.value && lhs.isInteger == rhs.isInteger && lhs.isNegative == rhs.isNegative
+  }
+
+}
+
+extension YAML.Number: Hashable {}
+
+extension YAML.Number: Sendable {}
+
+extension YAML.Number: Codable {}
+
+extension YAML.Number: CustomStringConvertible {
+
+  public var description: String { value }
+
+}
+
+
+extension YAML.MappingEntry: Equatable {}
+
+extension YAML.MappingEntry: Hashable {}
+
+extension YAML.MappingEntry: Sendable {}
+
+
+extension YAML.StringStyle: Equatable {}
+
+extension YAML.StringStyle: Hashable {}
+
+extension YAML.StringStyle: Sendable {}
+
+
+extension YAML.CollectionStyle: Hashable {}
+
+extension YAML.CollectionStyle: Equatable {}
+
+extension YAML.CollectionStyle: Sendable {}
+
 
 extension YAML: Equatable {
 
@@ -339,16 +404,8 @@ extension YAML: Equatable {
 }
 
 extension YAML: Hashable {}
-extension YAML: Value {
 
-  public var isNull: Bool {
-    if case .null = self {
-      return true
-    }
-    return false
-  }
-
-}
+extension YAML: Sendable {}
 
 extension YAML: CustomStringConvertible {
 
@@ -395,23 +452,13 @@ extension YAML: CustomStringConvertible {
 
 }
 
+extension YAML: Value {
 
-// MARK: Wrapping
-
-extension YAML {
-
-  public var unwrapped: Any? {
-    switch self {
-    case .null, .alias: return nil
-    case .bool(let value, _): return value
-    case .string(let value, _, _, _): return value
-    case .integer(let value, _): return value.numberValue
-    case .float(let value, _): return value.numberValue
-    case .sequence(let value, _, _, _): return Swift.Array(value.map(\.unwrapped))
-    case .mapping(let value, _, _, _): return Dictionary(uniqueKeysWithValues: value.map { entry in
-        (entry.key.stringValue!, entry.value.unwrapped)
-      })
+  public var isNull: Bool {
+    if case .null = self {
+      return true
     }
+    return false
   }
 
 }
@@ -453,7 +500,6 @@ extension YAML: ExpressibleByNilLiteral, ExpressibleByBooleanLiteral, Expressibl
 
 }
 
-
 extension YAML.Number: ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, ExpressibleByStringLiteral {
 
   public init(stringLiteral value: String) {
@@ -471,7 +517,7 @@ extension YAML.Number: ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, E
 }
 
 
-// Make encoders/decoders available in AnyValue namespace
+// Make encoders/decoders available in YAML namespace
 
 public extension YAML {
 


### PR DESCRIPTION
* Make format value tree types (e.g., JSON, YAML, etc.)  conform to Sendable.
* Added `Sendable` as a requirement to the `Value` protocol, requiring all value-tree types (and therefore all formats) to be `Sendable` moving forward.
* Add Swift 6 language mode/version for Swift 6+